### PR TITLE
feat: Implement parameter `mode` of action `fileCreate`

### DIFF
--- a/pkg/action/file.go
+++ b/pkg/action/file.go
@@ -146,7 +146,7 @@ func (a *fileCreate) Apply(_ context.Context) error {
 }
 
 func (a *fileCreate) String() string {
-	return fmt.Sprintf("fileCreate(mode=%d,overwrite=%t,path=%s)", a.mode, a.overwrite, a.path)
+	return fmt.Sprintf("fileCreate(mode=%o,overwrite=%t,path=%s)", a.mode, a.overwrite, a.path)
 }
 
 type FileDeleteFactory struct{}

--- a/pkg/action/file_test.go
+++ b/pkg/action/file_test.go
@@ -124,7 +124,7 @@ func TestFileCreate_Apply(t *testing.T) {
 				"mode":    "75r",
 				"path":    "test.txt",
 			},
-			wantError: errors.New("parse value of parameter `mode`: strconv.Atoi: parsing \"75r\": invalid syntax"),
+			wantError: errors.New("parse value of parameter `mode`: strconv.ParseUint: parsing \"75r\": invalid syntax"),
 		},
 	}
 


### PR DESCRIPTION
Parameter `mode` existed before this PR. Its value was not used.

This change implements setting the mode of the created file.