### PR TITLE
refactor: Make params of actions and filters a generic map

### DIFF
--- a/docs/task/actions/fileCreate.md
+++ b/docs/task/actions/fileCreate.md
@@ -41,7 +41,7 @@ Mode of the file to create. If the file exists, the file mode gets updated.
 | -------- | --------- |
 | Type     | `integer` |
 | Required | No        |
-| Default  | `644`     |
+| Default  | `0644`    |
 
 ### `overwrite`
 
@@ -97,5 +97,5 @@ actions:
       - content: |
           echo "Updating..."
         path: "update.sh"
-        mode: 755
+        mode: 0755
 ```

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -18,6 +18,6 @@ type Action interface {
 }
 
 type Factory interface {
-	Create(params map[string]string, taskPath string) (Action, error)
+	Create(params map[string]any, taskPath string) (Action, error)
 	Name() string
 }

--- a/pkg/action/file_test.go
+++ b/pkg/action/file_test.go
@@ -18,7 +18,7 @@ func TestFileCreate_Apply(t *testing.T) {
 			name:    "When parameter `content` is set and the file does not exist then it creates the file",
 			files:   map[string]string{},
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"content": "abc\n",
 				"path":    "test.txt",
 			},
@@ -40,7 +40,7 @@ func TestFileCreate_Apply(t *testing.T) {
 				return filepath.Join(tmpDir, "task.yaml")
 			},
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"contentFromFile": "content.txt",
 				"path":            "test.txt",
 			},
@@ -51,9 +51,9 @@ func TestFileCreate_Apply(t *testing.T) {
 			name:    "When `overwrite=false` and the file exists then it does not update the file",
 			files:   map[string]string{"test.txt": "abc\n"},
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"content":   "def\n",
-				"overwrite": "false",
+				"overwrite": false,
 				"path":      "test.txt",
 			},
 			wantFiles: map[string]string{"test.txt": "abc\n"},
@@ -62,9 +62,9 @@ func TestFileCreate_Apply(t *testing.T) {
 			name:    "When `overwrite=true` and the file exists then it updates the file",
 			files:   map[string]string{"test.txt": "abc\n"},
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"content":   "def\n",
-				"overwrite": "true",
+				"overwrite": true,
 				"path":      "test.txt",
 			},
 			wantFiles: map[string]string{"test.txt": "def\n"},
@@ -73,9 +73,9 @@ func TestFileCreate_Apply(t *testing.T) {
 			name:    "When `overwrite=true` and the file does not exist then it creates the file",
 			files:   map[string]string{},
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"content":   "def\n",
-				"overwrite": "true",
+				"overwrite": true,
 				"path":      "test.txt",
 			},
 			wantFiles: map[string]string{"test.txt": "def\n"},
@@ -84,7 +84,7 @@ func TestFileCreate_Apply(t *testing.T) {
 			name:    "When `path` contains directories and those directories do not exist then it creates the directories and the file",
 			files:   map[string]string{},
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"content": "abc\n",
 				"path":    "unit/test/test.txt",
 			},
@@ -93,7 +93,7 @@ func TestFileCreate_Apply(t *testing.T) {
 		{
 			name:    "When parameter `path` is not set then it errors",
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"content": "abc\n",
 			},
 			wantError: errors.New("required parameter `path` not set"),
@@ -101,7 +101,7 @@ func TestFileCreate_Apply(t *testing.T) {
 		{
 			name:    "When parameters `content` and `contentFromFile` are not set then it errors",
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path": "test.txt",
 			},
 			wantError: errors.New("either parameter `content` or `contentFromFile` is required"),
@@ -109,7 +109,7 @@ func TestFileCreate_Apply(t *testing.T) {
 		{
 			name:    "When parameters `content` and `contentFromFile` are both set then it errors",
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"content":         "abc\n",
 				"contentFromFile": "content.txt",
 				"path":            "test.txt",
@@ -117,14 +117,14 @@ func TestFileCreate_Apply(t *testing.T) {
 			wantError: errors.New("parameters `content` and `contentFromFile` cannot be set at the same time"),
 		},
 		{
-			name:    "When parameter `mode` is invalid then it errors",
+			name:    "When parameter `mode` is not an integer then it errors",
 			factory: FileCreateFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"content": "abc\n",
 				"mode":    "75r",
 				"path":    "test.txt",
 			},
-			wantError: errors.New("parse value of parameter `mode`: strconv.ParseUint: parsing \"75r\": invalid syntax"),
+			wantError: errors.New("parameter `mode` is of type string not int"),
 		},
 	}
 
@@ -138,9 +138,9 @@ func TestFileCreate_Apply_FileMode(t *testing.T) {
 	require.NoError(t, err)
 
 	fac := FileCreateFactory{}
-	a, err := fac.Create(map[string]string{
+	a, err := fac.Create(map[string]any{
 		"content": "echo Unit Test",
-		"mode":    "755",
+		"mode":    493, // 755 in octal
 		"path":    "test.sh",
 	}, "")
 	require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestFileDelete_Apply(t *testing.T) {
 			name:    "When the file exists then it deletes the file",
 			files:   map[string]string{"test.txt": "abc\n"},
 			factory: FileDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path": "test.txt",
 			},
 			wantFiles: map[string]string{},
@@ -169,7 +169,7 @@ func TestFileDelete_Apply(t *testing.T) {
 			name:    "When the file does not exist then it does nothing",
 			files:   map[string]string{},
 			factory: FileDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path": "test.txt",
 			},
 			wantFiles: map[string]string{},
@@ -178,7 +178,7 @@ func TestFileDelete_Apply(t *testing.T) {
 			name:      "When parameter `path` is not set then it errors",
 			files:     map[string]string{},
 			factory:   FileDeleteFactory{},
-			params:    map[string]string{},
+			params:    map[string]any{},
 			wantError: errors.New("required parameter `path` not set"),
 		},
 	}

--- a/pkg/action/line_in_file.go
+++ b/pkg/action/line_in_file.go
@@ -19,14 +19,33 @@ const (
 
 type LineDeleteFactory struct{}
 
-func (f LineDeleteFactory) Create(params map[string]string, _ string) (Action, error) {
-	path := params["path"]
-	if path == "" {
+func (f LineDeleteFactory) Create(params map[string]any, _ string) (Action, error) {
+	if params["path"] == nil {
 		return nil, fmt.Errorf("required parameter `path` not set")
 	}
+	path, ok := params["path"].(string)
+	if !ok {
+		return nil, fmt.Errorf("parameter `path` is of type %T not string", params["path"])
+	}
 
-	search := params["search"]
-	regexpRaw := params["regexp"]
+	var search string
+	if params["search"] != nil {
+		searchCast, ok := params["search"].(string)
+		if !ok {
+			return nil, fmt.Errorf("parameter `search` is of type %T not string", params["search"])
+		}
+		search = searchCast
+	}
+
+	var regexpRaw string
+	if params["regexp"] != nil {
+		regexpCast, ok := params["regexp"].(string)
+		if !ok {
+			return nil, fmt.Errorf("parameter `regexp` is of type %T not string", params["regexp"])
+		}
+		regexpRaw = regexpCast
+	}
+
 	if search == "" && regexpRaw == "" {
 		return nil, fmt.Errorf("either parameter `regexp` or `search` must be set")
 	}
@@ -97,10 +116,15 @@ func (d *lineDelete) String() string {
 
 type LineInsertFactory struct{}
 
-func (f LineInsertFactory) Create(params map[string]string, _ string) (Action, error) {
-	insertAt := params["insertAt"]
-	if insertAt == "" {
-		insertAt = "EOF"
+func (f LineInsertFactory) Create(params map[string]any, _ string) (Action, error) {
+	insertAt := "EOF"
+	if params["insertAt"] != nil {
+		insertAtCast, ok := params["insertAt"].(string)
+		if !ok {
+			return nil, fmt.Errorf("parameter `insertAt` is of type %T not string", params["insertAt"])
+		}
+
+		insertAt = insertAtCast
 	}
 
 	insertAt = strings.ToUpper(insertAt)
@@ -108,14 +132,20 @@ func (f LineInsertFactory) Create(params map[string]string, _ string) (Action, e
 		return nil, fmt.Errorf("invalid value of parameter `insertAt` - can be one of BOF,EOF")
 	}
 
-	path := params["path"]
-	if path == "" {
+	if params["path"] == nil {
 		return nil, fmt.Errorf("required parameter `path` not set")
 	}
+	path, ok := params["path"].(string)
+	if !ok {
+		return nil, fmt.Errorf("parameter `path` is of type %T not string", params["path"])
+	}
 
-	line := params["line"]
-	if line == "" {
+	if params["line"] == nil {
 		return nil, fmt.Errorf("required parameter `line` not set")
+	}
+	line, ok := params["line"].(string)
+	if !ok {
+		return nil, fmt.Errorf("parameter `path` is of type %T not string", params["line"])
 	}
 
 	return &lineInsert{
@@ -231,19 +261,41 @@ func (a *lineInsert) String() string {
 
 type LineReplaceFactory struct{}
 
-func (f LineReplaceFactory) Create(params map[string]string, _ string) (Action, error) {
-	path := params["path"]
-	if path == "" {
+func (f LineReplaceFactory) Create(params map[string]any, _ string) (Action, error) {
+	if params["path"] == nil {
 		return nil, fmt.Errorf("required parameter `path` not set")
 	}
-
-	line := params["line"]
-	if line == "" {
-		return nil, fmt.Errorf("required parameter `line` not set")
+	path, ok := params["path"].(string)
+	if !ok {
+		return nil, fmt.Errorf("parameter `path` is of type %T not string", params["path"])
 	}
 
-	regexpRaw := params["regexp"]
-	search := params["search"]
+	if params["line"] == nil {
+		return nil, fmt.Errorf("required parameter `line` not set")
+	}
+	line, ok := params["line"].(string)
+	if !ok {
+		return nil, fmt.Errorf("parameter `path` is of type %T not string", params["line"])
+	}
+
+	var search string
+	if params["search"] != nil {
+		searchCast, ok := params["search"].(string)
+		if !ok {
+			return nil, fmt.Errorf("parameter `search` is of type %T not string", params["search"])
+		}
+		search = searchCast
+	}
+
+	var regexpRaw string
+	if params["regexp"] != nil {
+		regexpCast, ok := params["regexp"].(string)
+		if !ok {
+			return nil, fmt.Errorf("parameter `regexp` is of type %T not string", params["regexp"])
+		}
+		regexpRaw = regexpCast
+	}
+
 	if search == "" && regexpRaw == "" {
 		return nil, fmt.Errorf("either parameter `regexp` or `search` must be set")
 	}

--- a/pkg/action/line_in_file_test.go
+++ b/pkg/action/line_in_file_test.go
@@ -15,7 +15,7 @@ func TestLineDelete_Apply(t *testing.T) {
 			name:    "When regexp matches a line then it deletes the line",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path":   "test.txt",
 				"regexp": "^ghi$",
 			},
@@ -25,7 +25,7 @@ func TestLineDelete_Apply(t *testing.T) {
 			name:    "When regexp matches multiple lines then it deletes each line",
 			files:   map[string]string{"test.txt": "abc\nghi\ndef\n\nghi\njkl"},
 			factory: LineDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path":   "test.txt",
 				"regexp": "^ghi$",
 			},
@@ -35,7 +35,7 @@ func TestLineDelete_Apply(t *testing.T) {
 			name:    "When regexp does not match a line then it leaves the file as-is",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path":   "test.txt",
 				"regexp": "^xyz$",
 			},
@@ -45,7 +45,7 @@ func TestLineDelete_Apply(t *testing.T) {
 			name:    "When parameter `path` contains a glob pattern then it deletes the line from each matching file",
 			files:   map[string]string{"test1.txt": testContent, "test2.txt": testContent},
 			factory: LineDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path":   "*.txt",
 				"regexp": "^ghi$",
 			},
@@ -55,7 +55,7 @@ func TestLineDelete_Apply(t *testing.T) {
 			name:    "When parameter `path` is not set then it errors",
 			files:   map[string]string{},
 			factory: LineDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"regexp": "^ghi$",
 			},
 			wantError: errors.New("required parameter `path` not set"),
@@ -64,7 +64,7 @@ func TestLineDelete_Apply(t *testing.T) {
 			name:    "When parameters `regexp` and `search` are not set then it errors",
 			files:   map[string]string{},
 			factory: LineDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path": "test.txt",
 			},
 			wantError: errors.New("either parameter `regexp` or `search` must be set"),
@@ -73,7 +73,7 @@ func TestLineDelete_Apply(t *testing.T) {
 			name:    "When parameters `regexp` and `search` are both set then it errors",
 			files:   map[string]string{},
 			factory: LineDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path":   "test.txt",
 				"regexp": "^ghi$",
 				"search": "ghi",
@@ -84,7 +84,7 @@ func TestLineDelete_Apply(t *testing.T) {
 			name:    "When parameter `regexp` is invalid then it errors",
 			files:   map[string]string{},
 			factory: LineDeleteFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path":   "test.txt",
 				"regexp": "[a-z",
 			},
@@ -103,7 +103,7 @@ func TestLineInsert_Apply(t *testing.T) {
 			name:    "When `line` and `path` are set then it adds the line at the end of the file",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineInsertFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line": "ttt",
 				"path": "test.txt",
 			},
@@ -113,7 +113,7 @@ func TestLineInsert_Apply(t *testing.T) {
 			name:    "When `path` is a glob pattern then it adds the line at the end of each matching file",
 			files:   map[string]string{"test1.txt": testContent, "test2.txt": testContent},
 			factory: LineInsertFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line": "ttt",
 				"path": "*.txt",
 			},
@@ -126,7 +126,7 @@ func TestLineInsert_Apply(t *testing.T) {
 			name:    "When parameter `insertAt=BOF` then it adds the line at the beginning of the file",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineInsertFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"insertAt": "BOF",
 				"line":     "ttt",
 				"path":     "test.txt",
@@ -137,7 +137,7 @@ func TestLineInsert_Apply(t *testing.T) {
 			name:    "When the value of `insertAt` is invalid then it errors",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineInsertFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"insertAt": "EXO",
 				"line":     "ttt",
 				"path":     "test.txt",
@@ -148,7 +148,7 @@ func TestLineInsert_Apply(t *testing.T) {
 			name:    "When the value of `insertAt` is not in upper-case then it still works",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineInsertFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"insertAt": "bOf",
 				"line":     "ttt",
 				"path":     "test.txt",
@@ -159,7 +159,7 @@ func TestLineInsert_Apply(t *testing.T) {
 			name:    "When `insertAt=BOF` and the line is already present then there is no change",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineInsertFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"insertAt": "BOF",
 				"line":     "abc",
 				"path":     "test.txt",
@@ -169,7 +169,7 @@ func TestLineInsert_Apply(t *testing.T) {
 		{
 			name:    "When `path` is not set then it errors",
 			factory: LineInsertFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line": "jkl",
 			},
 			wantError: errors.New("required parameter `path` not set"),
@@ -177,7 +177,7 @@ func TestLineInsert_Apply(t *testing.T) {
 		{
 			name:    "When `line` is not set then it errors",
 			factory: LineInsertFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path": "test.txt",
 			},
 			wantError: errors.New("required parameter `line` not set"),
@@ -195,7 +195,7 @@ func TestLineReplace_Apply(t *testing.T) {
 			name:    "When `regexp` matches a line then it replaces the line",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line":   "ttt",
 				"path":   "test.txt",
 				"regexp": "^def$",
@@ -206,7 +206,7 @@ func TestLineReplace_Apply(t *testing.T) {
 			name:    "When `search` matches a line then it replaces the line",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line":   "ttt",
 				"path":   "test.txt",
 				"search": "def",
@@ -217,7 +217,7 @@ func TestLineReplace_Apply(t *testing.T) {
 			name:    "When `path` contains a glob pattern then it replaces the line in each matching file",
 			files:   map[string]string{"test1.txt": testContent, "test2.txt": testContent},
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line":   "ttt",
 				"path":   "*.txt",
 				"search": "def",
@@ -228,7 +228,7 @@ func TestLineReplace_Apply(t *testing.T) {
 			name:    "When `regexp` matches multiple lines then it replaces each line",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line":   "ttt",
 				"path":   "test.txt",
 				"regexp": "def|ghi",
@@ -239,7 +239,7 @@ func TestLineReplace_Apply(t *testing.T) {
 			name:    "When `regexp` contains match groups then it allows its usage",
 			files:   map[string]string{"test.txt": testContent},
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line":   "${1}T${2}",
 				"path":   "test.txt",
 				"regexp": "(.+)h(.+)",
@@ -249,7 +249,7 @@ func TestLineReplace_Apply(t *testing.T) {
 		{
 			name:    "When `path` is not set then it errors",
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line":   "ttt",
 				"search": "def",
 			},
@@ -258,7 +258,7 @@ func TestLineReplace_Apply(t *testing.T) {
 		{
 			name:    "When `regexp` and `search` are not set then it errors",
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line": "ttt",
 				"path": "test.txt",
 			},
@@ -267,7 +267,7 @@ func TestLineReplace_Apply(t *testing.T) {
 		{
 			name:    "When `regexp` and `search` are both set then it errors",
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line":   "ttt",
 				"path":   "test.txt",
 				"regexp": "^jkl$",
@@ -278,7 +278,7 @@ func TestLineReplace_Apply(t *testing.T) {
 		{
 			name:    "When `line` is not set then it errors",
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"path":   "test.txt",
 				"search": "def",
 			},
@@ -287,7 +287,7 @@ func TestLineReplace_Apply(t *testing.T) {
 		{
 			name:    "When the value of `regexp` is invalid then it errors",
 			factory: LineReplaceFactory{},
-			params: map[string]string{
+			params: map[string]any{
 				"line":   "ttt",
 				"path":   "test.txt",
 				"regexp": "[a-z",

--- a/pkg/action/util_test.go
+++ b/pkg/action/util_test.go
@@ -18,7 +18,7 @@ type testCase struct {
 	bootstrap func() string
 	files     map[string]string
 	factory   Factory
-	params    map[string]string
+	params    map[string]any
 	wantError error
 	wantFiles map[string]string
 }

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -50,7 +50,7 @@ func (f FileFactory) Create(params map[string]any) (Filter, error) {
 	}
 	path, ok := params["path"].(string)
 	if !ok {
-		return nil, fmt.Errorf("required parameter `path` is of type %T not string", path)
+		return nil, fmt.Errorf("required parameter `path` is of type %T not string", params["path"])
 	}
 
 	return &File{Path: path}, nil

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -34,7 +34,7 @@ type Filter interface {
 }
 
 type Factory interface {
-	Create(params map[string]string) (Filter, error)
+	Create(params map[string]any) (Filter, error)
 	Name() string
 }
 
@@ -44,10 +44,13 @@ func (f FileFactory) Name() string {
 	return "file"
 }
 
-func (f FileFactory) Create(params map[string]string) (Filter, error) {
-	path := params["path"]
-	if path == "" {
+func (f FileFactory) Create(params map[string]any) (Filter, error) {
+	if params["path"] == nil {
 		return nil, fmt.Errorf("required parameter `path` not set")
+	}
+	path, ok := params["path"].(string)
+	if !ok {
+		return nil, fmt.Errorf("required parameter `path` is of type %T not string", path)
 	}
 
 	return &File{Path: path}, nil
@@ -76,15 +79,21 @@ func (f FileContentFactory) Name() string {
 	return "fileContent"
 }
 
-func (f FileContentFactory) Create(params map[string]string) (Filter, error) {
-	path := params["path"]
-	if path == "" {
+func (f FileContentFactory) Create(params map[string]any) (Filter, error) {
+	if params["path"] == nil {
 		return nil, fmt.Errorf("required parameter `path` not set")
 	}
+	path, ok := params["path"].(string)
+	if !ok {
+		return nil, fmt.Errorf("required parameter `path` is of type %T not string", params["path"])
+	}
 
-	reRaw := params["regexp"]
-	if reRaw == "" {
+	if params["regexp"] == nil {
 		return nil, fmt.Errorf("required parameter `regexp` not set")
+	}
+	reRaw, ok := params["regexp"].(string)
+	if !ok {
+		return nil, fmt.Errorf("required parameter `regexp` is of type %T not string", params["regexp"])
 	}
 
 	re, err := regexp.Compile(reRaw)
@@ -141,10 +150,13 @@ func (f RepositoryFactory) Name() string {
 	return "repository"
 }
 
-func (f RepositoryFactory) Create(params map[string]string) (Filter, error) {
-	host := params["host"]
-	if host == "" {
+func (f RepositoryFactory) Create(params map[string]any) (Filter, error) {
+	if params["host"] == nil {
 		return nil, fmt.Errorf("required parameter `host` not set")
+	}
+	host, ok := params["host"].(string)
+	if !ok {
+		return nil, fmt.Errorf("parameter `host` is of type %T not string", params["host"])
 	}
 
 	hostRe, err := regexp.Compile(str.EncloseRegex(host))
@@ -152,9 +164,12 @@ func (f RepositoryFactory) Create(params map[string]string) (Filter, error) {
 		return nil, fmt.Errorf("compile parameter `host` to regular expression: %w", err)
 	}
 
-	owner := params["owner"]
-	if owner == "" {
+	if params["owner"] == nil {
 		return nil, fmt.Errorf("required parameter `owner` not set")
+	}
+	owner, ok := params["owner"].(string)
+	if !ok {
+		return nil, fmt.Errorf("parameter `owner` is of type %T not string", params["owner"])
 	}
 
 	ownerRe, err := regexp.Compile(str.EncloseRegex(owner))
@@ -162,9 +177,12 @@ func (f RepositoryFactory) Create(params map[string]string) (Filter, error) {
 		return nil, fmt.Errorf("compile parameter `owner` to regular expression: %w", err)
 	}
 
-	name := params["name"]
-	if name == "" {
+	if params["name"] == nil {
 		return nil, fmt.Errorf("required parameter `name` not set")
+	}
+	name, ok := params["name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("required parameter `name` is of type %T not string", params["name"])
 	}
 
 	nameRe, err := regexp.Compile(str.EncloseRegex(name))

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -39,7 +39,7 @@ func (r *repositoryMock) Owner() string {
 
 func TestFileFactory_Create(t *testing.T) {
 	fac := FileFactory{}
-	_, err := fac.Create(map[string]string{})
+	_, err := fac.Create(map[string]any{})
 	require.ErrorContains(t, err, "required parameter `path` not set")
 }
 
@@ -50,14 +50,14 @@ func TestFile_Do(t *testing.T) {
 
 	fac := FileFactory{}
 
-	f, err := fac.Create(map[string]string{"path": "test.yaml"})
+	f, err := fac.Create(map[string]any{"path": "test.yaml"})
 	require.NoError(t, err)
 	result, err := f.Do(ctx)
 
 	require.NoError(t, err)
 	require.True(t, result)
 
-	f, err = fac.Create(map[string]string{"path": "test.json"})
+	f, err = fac.Create(map[string]any{"path": "test.json"})
 	require.NoError(t, err)
 	result, err = f.Do(ctx)
 
@@ -67,13 +67,13 @@ func TestFile_Do(t *testing.T) {
 
 func TestFileContentFactory_Create(t *testing.T) {
 	fac := FileContentFactory{}
-	_, err := fac.Create(map[string]string{})
+	_, err := fac.Create(map[string]any{})
 	require.ErrorContains(t, err, "required parameter `path` not set")
 
-	_, err = fac.Create(map[string]string{"path": "path.txt"})
+	_, err = fac.Create(map[string]any{"path": "path.txt"})
 	require.ErrorContains(t, err, "required parameter `regexp` not set")
 
-	_, err = fac.Create(map[string]string{"path": "path.txt", "regexp": "[a-z"})
+	_, err = fac.Create(map[string]any{"path": "path.txt", "regexp": "[a-z"})
 	require.ErrorContains(t, err, "compile parameter `regexp` to regular expression: error parsing regexp: missing closing ]: `[a-z`")
 }
 
@@ -88,14 +88,14 @@ ghi
 
 	fac := FileContentFactory{}
 
-	f, err := fac.Create(map[string]string{"path": "test.txt", "regexp": "d?f"})
+	f, err := fac.Create(map[string]any{"path": "test.txt", "regexp": "d?f"})
 	require.NoError(t, err)
 	result, err := f.Do(ctx)
 
 	require.NoError(t, err)
 	require.True(t, result)
 
-	f, err = fac.Create(map[string]string{"path": "test.txt", "regexp": "jkl"})
+	f, err = fac.Create(map[string]any{"path": "test.txt", "regexp": "jkl"})
 	require.NoError(t, err)
 	result, err = f.Do(ctx)
 
@@ -105,36 +105,36 @@ ghi
 
 func TestRepositoryFactory_Create(t *testing.T) {
 	fac := RepositoryFactory{}
-	_, err := fac.Create(map[string]string{})
+	_, err := fac.Create(map[string]any{})
 	require.ErrorContains(t, err, "required parameter `host` not set")
 
-	_, err = fac.Create(map[string]string{"host": "github.com"})
+	_, err = fac.Create(map[string]any{"host": "github.com"})
 	require.ErrorContains(t, err, "required parameter `owner` not set")
 
-	_, err = fac.Create(map[string]string{
+	_, err = fac.Create(map[string]any{
 		"host":  "github.com",
 		"owner": "wndhydrnt",
 	})
 	require.ErrorContains(t, err, "required parameter `name` not set")
 
-	_, err = fac.Create(map[string]string{
+	_, err = fac.Create(map[string]any{
 		"host":  "github.com",
 		"owner": "wndhydrnt",
 	})
 	require.ErrorContains(t, err, "required parameter `name` not set")
 
-	_, err = fac.Create(map[string]string{
+	_, err = fac.Create(map[string]any{
 		"host": "(github.com",
 	})
 	require.ErrorContains(t, err, "compile parameter `host` to regular expression: error parsing regexp: missing closing ): `^(github.com$`")
 
-	_, err = fac.Create(map[string]string{
+	_, err = fac.Create(map[string]any{
 		"host":  "github.com",
 		"owner": "(wndhydrnt",
 	})
 	require.ErrorContains(t, err, "compile parameter `owner` to regular expression: error parsing regexp: missing closing ): `^(wndhydrnt$`")
 
-	_, err = fac.Create(map[string]string{
+	_, err = fac.Create(map[string]any{
 		"host":  "github.com",
 		"owner": "wndhydrnt",
 		"name":  "(saturn-bot",
@@ -145,7 +145,7 @@ func TestRepositoryFactory_Create(t *testing.T) {
 func TestRepository_Do(t *testing.T) {
 	fac := RepositoryFactory{}
 
-	f, err := fac.Create(map[string]string{"host": "github.com", "owner": "wndhydrnt", "name": "rcmt"})
+	f, err := fac.Create(map[string]any{"host": "github.com", "owner": "wndhydrnt", "name": "rcmt"})
 	require.NoError(t, err)
 
 	cases := []struct {

--- a/pkg/task/schema/schema.go
+++ b/pkg/task/schema/schema.go
@@ -79,7 +79,7 @@ type TaskActionsElem struct {
 }
 
 // Key/value pairs passed as parameters to the action.
-type TaskActionsElemParams map[string]string
+type TaskActionsElemParams map[string]interface{}
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *TaskActionsElem) UnmarshalJSON(b []byte) error {
@@ -129,7 +129,7 @@ type TaskFiltersElem struct {
 }
 
 // Key/value pairs passed as parameters to the filter.
-type TaskFiltersElemParams map[string]string
+type TaskFiltersElemParams map[string]interface{}
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *TaskFiltersElem) UnmarshalJSON(b []byte) error {

--- a/pkg/task/schema/task.schema.json
+++ b/pkg/task/schema/task.schema.json
@@ -16,10 +16,7 @@
           },
           "params": {
             "type": "object",
-            "description": "Key/value pairs passed as parameters to the action.",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "description": "Key/value pairs passed as parameters to the action."
           }
         },
         "required": ["action"]
@@ -78,10 +75,7 @@
           },
           "params": {
             "type": "object",
-            "description": "Key/value pairs passed as parameters to the filter.",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "description": "Key/value pairs passed as parameters to the filter."
           },
           "reverse": {
             "type": "boolean",

--- a/pkg/task/yaml.go
+++ b/pkg/task/yaml.go
@@ -43,7 +43,7 @@ func readTasksYaml(actionFactories options.ActionFactories, filterFactories opti
 		wrapper.Task = task
 		wrapper.actions, err = createActionsForTask(wrapper.Task.Actions, actionFactories, taskFile)
 		if err != nil {
-			return nil, fmt.Errorf("parse actions of task file '%s': %w", taskFile, err)
+			return nil, fmt.Errorf("parse actions of task: %w", err)
 		}
 
 		wrapper.filters, err = createFiltersForTask(wrapper.Task.Filters, filterFactories)


### PR DESCRIPTION
Allows for more flexible definition of parameters.

Code needs to properly cast types.