### PR TITLE
fix: exec action fails when the name of a command is set

### DIFF
--- a/pkg/action/exec.go
+++ b/pkg/action/exec.go
@@ -39,7 +39,9 @@ func (f ExecFactory) Create(params map[string]any, taskPath string) (Action, err
 		return nil, fmt.Errorf("parameter `command` is of type %T not string", params["command"])
 	}
 
-	if !filepath.IsAbs(command) {
+	// Try to resolve relative path if command is not a name like "terraform"
+	// or not an absolute path like "/usr/bin/terraform".
+	if command != filepath.Base(command) && !filepath.IsAbs(command) {
 		taskDir := filepath.Dir(taskPath)
 		commandAbs, err := filepath.Abs(filepath.Join(taskDir, command))
 		if err != nil {

--- a/pkg/action/exec_test.go
+++ b/pkg/action/exec_test.go
@@ -43,6 +43,38 @@ func TestExec_Apply(t *testing.T) {
 			wantFiles: map[string]string{"exec.txt": "exec test\n"},
 		},
 		{
+			name: "When the command points to a name then it executes the command",
+			bootstrap: func() string {
+				tmpDir, err := os.MkdirTemp("", "*")
+				require.NoError(t, err)
+				return filepath.Join(tmpDir, "task.yaml")
+			},
+			factory: ExecFactory{},
+			params: map[string]any{
+				"args":    []any{"-c", "echo 'name test' >> name.txt"},
+				"command": "sh",
+				"timeout": "1m",
+			},
+			wantError: nil,
+			wantFiles: map[string]string{"name.txt": "name test\n"},
+		},
+		{
+			name: "When the command point to an absolute path then it executes the command",
+			bootstrap: func() string {
+				tmpDir, err := os.MkdirTemp("", "*")
+				require.NoError(t, err)
+				return filepath.Join(tmpDir, "task.yaml")
+			},
+			factory: ExecFactory{},
+			params: map[string]any{
+				"args":    []any{"-c", "echo 'abs test' >> abs.txt"},
+				"command": "/bin/sh",
+				"timeout": "1m",
+			},
+			wantError: nil,
+			wantFiles: map[string]string{"abs.txt": "abs test\n"},
+		},
+		{
 			name:    "When parameter args not a list then it errors",
 			factory: ExecFactory{},
 			params: map[string]any{


### PR DESCRIPTION
Example action:
```yaml
actions:
  - action: exec
    params:
      args: ["fmt", "."]
      command: terraform
```

leads to the error:
```
action exec(args=fmt,., command=/path/of/task/terraform, timeout=2m0s) failed: fork/exec /path/of/task/terraform: no such file or directory
```