### PR TITLE
refactor(log): Use zap for logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/spf13/cobra"
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 )
 
 var (
@@ -41,10 +41,10 @@ func handleError(err error, out io.Writer) {
 
 	var validationError *jsonschema.ValidationError
 	if errors.As(err, &validationError) {
-		slog.Error("Configuration file contains errors:")
+		log.Log().Error("Configuration file contains errors:")
 		fmt.Fprintf(out, "%s\n", validationError.Error())
 	} else {
-		slog.Error("command failed", "err", err)
+		log.Log().Error("command failed", "error", err)
 	}
 
 	os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,8 @@ require (
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tetratelabs/wazero v1.7.3 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,10 @@ github.com/xanzy/go-gitlab v0.97.0/go.mod h1:ETg8tcj4OhrB84UEgeE8dSuV/0h4BBL1uOV
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/pkg/action/exec.go
+++ b/pkg/action/exec.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 )
 
 type ExecFactory struct{}
@@ -118,6 +119,6 @@ type logAdapter struct {
 }
 
 func (la *logAdapter) Write(p []byte) (n int, err error) {
-	slog.Debug(strings.TrimSpace(string(p)), "command", la.name)
+	log.Log().Debugw(strings.TrimSpace(string(p)), "command", la.name)
 	return len(p), nil
 }

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"log/slog"
 	"strings"
 	"time"
 
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	gsTemplate "github.com/wndhydrnt/saturn-bot/pkg/template"
 )
 
@@ -168,7 +168,7 @@ func CreatePullRequestCommentWithIdentifier(body string, identifier string, pr i
 		}
 	}
 
-	slog.Debug("Create comment on pull request with identifier", "identifier", identifier, "repository", repo.FullName())
+	log.Log().Debugf("Create comment on pull request of repository %s with identifier %s", repo.FullName(), identifier)
 	return repo.CreatePullRequestComment(prefix+"\n"+body, pr)
 }
 
@@ -185,7 +185,7 @@ func DeletePullRequestCommentByIdentifier(identifier string, pr interface{}, rep
 	prefix := fmt.Sprintf("<!-- saturn-bot::{%s} -->", identifier)
 	for _, comment := range comments {
 		if strings.HasPrefix(comment.Body, prefix) {
-			slog.Debug("Delete comment on pull request with identifier", "identifier", identifier, "repository", repo.FullName())
+			log.Log().Debugf("Delete comment on pull request of repository %s with identifier %s", repo.FullName(), identifier)
 			err := repo.DeletePullRequestComment(comment, pr)
 			if err != nil {
 				return fmt.Errorf("delete comment by identifier %s: %w", identifier, err)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,52 +4,64 @@ import (
 	"context"
 	"io"
 	"log"
-	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/lmittmann/tint"
 	"github.com/mattn/go-isatty"
 	"github.com/wndhydrnt/saturn-bot/pkg/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
 	ctx                 = context.Background()
 	defaultHclogAdapter = &hclogAdapter{}
-	gitLogger           *slog.Logger
+	gitLogger           *zap.SugaredLogger
 )
 
+var (
+	DefaultLogger *zap.SugaredLogger
+)
+
+func Log() *zap.SugaredLogger {
+	return DefaultLogger
+}
+
+func init() {
+	// Ensure that a logger is always present
+	logger := zap.Must(zap.NewProduction())
+	DefaultLogger = logger.Sugar()
+}
+
 type hclogAdapter struct {
-	level      *slog.LevelVar
 	levelHclog hclog.Level
-	logger     *slog.Logger
+	logger     *zap.SugaredLogger
 	name       string
 }
 
 func (l *hclogAdapter) Log(level hclog.Level, msg string, args ...interface{}) {
-	slogLvl := mapHclogToSlogLevel(level)
-	l.logger.Log(context.Background(), slogLvl, msg, args...)
+	lvl := mapHclogToLevel(level)
+	l.logger.Logw(lvl, msg, args...)
 }
 
 func (l *hclogAdapter) Trace(msg string, args ...interface{}) {
-	l.logger.Debug(msg, args...)
+	l.logger.Debugf(msg, args...)
 }
 
 func (l *hclogAdapter) Debug(msg string, args ...interface{}) {
-	l.logger.Debug(msg, args...)
+	l.logger.Debugf(msg, args...)
 }
 
 func (l *hclogAdapter) Info(msg string, args ...interface{}) {
-	l.logger.Info(msg, args...)
+	l.logger.Infof(msg, args...)
 }
 
 func (l *hclogAdapter) Warn(msg string, args ...interface{}) {
-	l.logger.Warn(msg, args...)
+	l.logger.Warnf(msg, args...)
 }
 
 func (l *hclogAdapter) Error(msg string, args ...interface{}) {
-	l.logger.Error(msg, args...)
+	l.logger.Errorf(msg, args...)
 }
 
 func (l *hclogAdapter) IsTrace() bool {
@@ -57,19 +69,19 @@ func (l *hclogAdapter) IsTrace() bool {
 }
 
 func (l *hclogAdapter) IsDebug() bool {
-	return l.logger.Enabled(ctx, slog.LevelDebug)
+	return l.logger.Level() == zapcore.DebugLevel
 }
 
 func (l *hclogAdapter) IsInfo() bool {
-	return l.logger.Enabled(ctx, slog.LevelInfo)
+	return l.logger.Level() == zapcore.InfoLevel
 }
 
 func (l *hclogAdapter) IsWarn() bool {
-	return l.logger.Enabled(ctx, slog.LevelWarn)
+	return l.logger.Level() == zapcore.WarnLevel
 }
 
 func (l *hclogAdapter) IsError() bool {
-	return l.logger.Enabled(ctx, slog.LevelError)
+	return l.logger.Level() == zapcore.ErrorLevel
 }
 
 func (l *hclogAdapter) ImpliedArgs() []interface{} {
@@ -77,7 +89,7 @@ func (l *hclogAdapter) ImpliedArgs() []interface{} {
 }
 
 func (l *hclogAdapter) With(args ...interface{}) hclog.Logger {
-	logger := slog.With(args...)
+	logger := l.logger.With(args...)
 	return &hclogAdapter{logger: logger}
 }
 
@@ -86,20 +98,16 @@ func (l *hclogAdapter) Name() string {
 }
 
 func (l *hclogAdapter) Named(name string) hclog.Logger {
-	logger := l.logger.WithGroup(l.name + "." + name)
+	logger := l.logger.Named(l.name + "." + name)
 	return &hclogAdapter{logger: logger, name: name}
 }
 
 func (l *hclogAdapter) ResetNamed(name string) hclog.Logger {
-	logger := l.logger.WithGroup(name)
+	logger := l.logger.Named(name)
 	return &hclogAdapter{logger: logger, name: name}
 }
 
-func (l *hclogAdapter) SetLevel(level hclog.Level) {
-	slogLevel := mapHclogToSlogLevel(level)
-	l.level.Set(slogLevel)
-	l.levelHclog = level
-}
+func (l *hclogAdapter) SetLevel(level hclog.Level) {}
 
 func (l *hclogAdapter) GetLevel() hclog.Level {
 	return l.levelHclog
@@ -113,48 +121,47 @@ func (l *hclogAdapter) StandardWriter(_ *hclog.StandardLoggerOptions) io.Writer 
 	return os.Stderr
 }
 
-func mapHclogToSlogLevel(in hclog.Level) slog.Level {
+func mapHclogToLevel(in hclog.Level) zapcore.Level {
 	switch in {
 	case hclog.Debug:
-		return slog.LevelDebug
+		return zap.DebugLevel
 	case hclog.Error:
-		return slog.LevelError
+		return zap.ErrorLevel
 	case hclog.Info:
-		return slog.LevelInfo
+		return zap.InfoLevel
 	case hclog.NoLevel:
-		return slog.LevelError
+		return zap.WarnLevel
 	case hclog.Off:
-		return slog.LevelError
+		return zap.DebugLevel
 	case hclog.Warn:
-		return slog.LevelWarn
+		return zap.WarnLevel
 	case hclog.Trace:
-		return slog.LevelDebug
+		return zap.DebugLevel
 	}
 
-	return slog.LevelInfo
+	return zap.InfoLevel
 }
 
 func InitLog(format config.ConfigurationLogFormat, level config.ConfigurationLogLevel, levelGit config.ConfigurationGitLogLevel) {
-	lvl := logStringToLevel(string(level))
-	w := os.Stderr
-	isTty := isatty.IsTerminal(w.Fd())
-	handler := newHandler(string(format), isTty, lvl, w)
-	logger := slog.New(handler)
-	slog.SetDefault(logger)
-	defaultHclogAdapter.level = lvl
+	loggerCfg := newConfig(format)
+	loggerCfg.Level = zap.NewAtomicLevelAt(logStringToLevel(string(level)))
+
+	logger := zap.Must(loggerCfg.Build())
+	DefaultLogger = logger.Sugar()
+
 	defaultHclogAdapter.levelHclog = hclog.Info
-	defaultHclogAdapter.logger = logger
+	defaultHclogAdapter.logger = DefaultLogger
 	defaultHclogAdapter.name = "plugin"
 	lvlGit := logStringToLevel(string(levelGit))
-	handlerGit := newHandler(string(format), isTty, lvlGit, w)
-	gitLogger = slog.New(handlerGit)
+	gitLogger = DefaultLogger.
+		WithOptions(zap.IncreaseLevel(lvlGit))
 }
 
 func DefaultHclogAdapter() hclog.Logger {
 	return defaultHclogAdapter
 }
 
-func GitLogger() *slog.Logger {
+func GitLogger() *zap.SugaredLogger {
 	if gitLogger == nil {
 		panic("git logger not initialized")
 	}
@@ -162,41 +169,56 @@ func GitLogger() *slog.Logger {
 	return gitLogger
 }
 
-func logStringToLevel(level string) *slog.LevelVar {
-	lvl := new(slog.LevelVar)
-	switch strings.ToLower(level) {
-	case "debug":
-		lvl.Set(slog.LevelDebug)
-	case "error":
-		lvl.Set(slog.LevelError)
-	case "warn":
-		lvl.Set(slog.LevelWarn)
-	case "info":
-		lvl.Set(slog.LevelInfo)
-	default:
-		slog.Warn("Unknown log level, falling back to info", "unknown", level)
-		lvl.Set(slog.LevelInfo)
+func logStringToLevel(level string) zapcore.Level {
+	lvl, err := zapcore.ParseLevel(level)
+	if err != nil {
+		lvl = zapcore.InfoLevel
 	}
 
 	return lvl
 }
 
-func newHandler(format string, isTty bool, level *slog.LevelVar, w io.Writer) slog.Handler {
-	switch format {
-	case "console":
-		return tint.NewHandler(w, &tint.Options{
-			NoColor: !isTty,
-			Level:   level,
-		})
-	case "json":
-		return slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level})
-	default:
-		if isTty {
-			return tint.NewHandler(w, &tint.Options{
-				Level: level,
-			})
+func newConfig(format config.ConfigurationLogFormat) zap.Config {
+	zapCfg := zap.NewProductionConfig()
+	var encoderFormat string
+	if format == "auto" {
+		if isatty.IsTerminal(os.Stderr.Fd()) {
+			encoderFormat = "console"
 		} else {
-			return slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level})
+			encoderFormat = "json"
 		}
 	}
+
+	if encoderFormat != "console" && encoderFormat != "json" {
+		encoderFormat = "json"
+	}
+
+	if encoderFormat == "console" {
+		zapCfg.DisableCaller = true
+		zapCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	}
+
+	if encoderFormat == "json" {
+		zapCfg.EncoderConfig.EncodeTime = zapcore.EpochMillisTimeEncoder
+		zapCfg.EncoderConfig.TimeKey = "timestamp"
+	}
+
+	zapCfg.Encoding = encoderFormat
+	return zapCfg
+}
+
+func FieldDryRun(v bool) zap.Field {
+	const key = "saturn_bot.dryRun"
+	return zap.Bool(key, v)
+}
+
+func FieldRepo(name string) zap.Field {
+	const key = "saturn_bot.repository"
+	return zap.String(key, name)
+}
+
+func FieldTask(name string) zap.Field {
+	const key = "saturn_bot.task"
+	return zap.String(key, name)
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -3,7 +3,6 @@ package options
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/wndhydrnt/saturn-bot/pkg/config"
 	"github.com/wndhydrnt/saturn-bot/pkg/filter"
 	"github.com/wndhydrnt/saturn-bot/pkg/host"
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	sLog "github.com/wndhydrnt/saturn-bot/pkg/log"
 )
 
@@ -128,11 +128,11 @@ func Initialize(opts *Opts) error {
 		dataDir = *opts.Config.DataDir
 	}
 
-	slog.Info(fmt.Sprintf("Using data directory %s", dataDir))
+	log.Log().Infof("Using data directory %s", dataDir)
 	info, err := os.Stat(dataDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			slog.Info("Creating data directory", "path", *opts.Config.DataDir)
+			log.Log().Infof("Creating data directory %s", *opts.Config.DataDir)
 			mkdirErr := os.MkdirAll(*opts.Config.DataDir, 0700)
 			if mkdirErr != nil {
 				return fmt.Errorf("create data directory: %w", err)

--- a/pkg/server/api/work.go
+++ b/pkg/server/api/work.go
@@ -3,12 +3,13 @@ package api
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"net/http"
 
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/db"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/service"
+	"go.uber.org/zap"
 )
 
 type WorkHandler struct {
@@ -23,7 +24,7 @@ func (wh *WorkHandler) GetWorkV1(_ context.Context) (openapi.ImplResponse, error
 			return openapi.Response(http.StatusOK, body), nil
 		}
 
-		slog.Error("Failed to get next run", "error", err)
+		log.Log().Errorw("Failed to get next run", zap.Error(err))
 		return openapi.Response(http.StatusInternalServerError, serverError), nil
 	}
 

--- a/pkg/server/service/taskservice.go
+++ b/pkg/server/service/taskservice.go
@@ -4,10 +4,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"time"
 
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/db"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/task"
 	"gorm.io/gorm"
@@ -31,7 +31,7 @@ func (ts *TaskService) SyncDbTasks() error {
 				return tx.Error
 			}
 
-			slog.Debug("Creating task in DB", "task", t.TaskName)
+			log.Log().Debugf("Creating task %s in DB", t.TaskName)
 			taskDB.Hash = t.Hash
 			taskDB.Name = t.TaskName
 			err := ts.db.Transaction(func(tx *gorm.DB) error {
@@ -57,7 +57,7 @@ func (ts *TaskService) SyncDbTasks() error {
 		} else {
 			if taskDB.Hash != t.Hash {
 				taskDB.Hash = t.Hash
-				slog.Debug("Updating task in DB", "task", taskDB.Name)
+				log.Log().Debugf("Updating task %s in DB", taskDB.Name)
 				run := db.Run{
 					Reason:        0,
 					ScheduleAfter: time.Now(),

--- a/pkg/task/plugin.go
+++ b/pkg/task/plugin.go
@@ -3,7 +3,6 @@ package task
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"os/exec"
 	"path/filepath"
 
@@ -12,6 +11,7 @@ import (
 	proto "github.com/wndhydrnt/saturn-bot-go/protocol/v1"
 	gsContext "github.com/wndhydrnt/saturn-bot/pkg/context"
 	"github.com/wndhydrnt/saturn-bot/pkg/host"
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	gsLog "github.com/wndhydrnt/saturn-bot/pkg/log"
 )
 
@@ -72,7 +72,7 @@ func newPluginWrapper(opts startPluginOptions) (*pluginWrapper, error) {
 		return nil, fmt.Errorf("get plugin: %w", err)
 	}
 
-	slog.Debug("Registered plugin", "name", getPluginResp.GetName())
+	log.Log().Debugf("Registered plugin %s", getPluginResp.GetName())
 	return &pluginWrapper{
 		action:   &PluginAction{Provider: provider},
 		client:   client,

--- a/pkg/task/schema/read.go
+++ b/pkg/task/schema/read.go
@@ -7,16 +7,16 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"log/slog"
 	"os"
 
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"gopkg.in/yaml.v3"
 )
 
 // Read return all Tasks from the file at `path`.
 // It also calculates the hash of the file.
 func Read(path string) ([]Task, []hash.Hash, error) {
-	slog.Debug(fmt.Sprintf("Reading task file %s", path))
+	log.Log().Debugf("Reading task file %s", path)
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read task file '%s': %w", path, err)
@@ -65,7 +65,7 @@ func Read(path string) ([]Task, []hash.Hash, error) {
 			}
 		}
 
-		slog.Debug(fmt.Sprintf("Found task %s", task.Name))
+		log.Log().Debugf("Found task %s", task.Name)
 		result = append(result, task)
 		hashes = append(hashes, checksum)
 	}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -3,7 +3,6 @@ package task
 import (
 	"cmp"
 	"fmt"
-	"log/slog"
 	"path"
 	"path/filepath"
 	"time"
@@ -12,8 +11,10 @@ import (
 	"github.com/wndhydrnt/saturn-bot/pkg/action"
 	"github.com/wndhydrnt/saturn-bot/pkg/filter"
 	"github.com/wndhydrnt/saturn-bot/pkg/host"
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/options"
 	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
+	"go.uber.org/zap"
 )
 
 //go:generate go-jsonschema --extra-imports -p schema -t ./schema/task.schema.json --output ./schema/schema.go
@@ -174,7 +175,7 @@ func (tw *Wrapper) OnPrClosed(repository host.Repository) error {
 	for _, p := range tw.plugins {
 		err := p.onPrClosed(repository)
 		if err != nil {
-			slog.Error("OnPrClosed event of plugin failed", "err", err)
+			log.Log().Errorw("OnPrClosed event of plugin failed", zap.Error(err))
 		}
 	}
 
@@ -185,7 +186,7 @@ func (tw *Wrapper) OnPrCreated(repository host.Repository) error {
 	for _, p := range tw.plugins {
 		err := p.onPrCreated(repository)
 		if err != nil {
-			slog.Error("OnPrCreated event of plugin failed", "err", err)
+			log.Log().Errorw("OnPrCreated event of plugin failed", zap.Error(err))
 		}
 	}
 
@@ -196,7 +197,7 @@ func (tw *Wrapper) OnPrMerged(repository host.Repository) error {
 	for _, p := range tw.plugins {
 		err := p.onPrMerged(repository)
 		if err != nil {
-			slog.Error("OnPrMerged event of plugin failed", "err", err)
+			log.Log().Errorw("OnPrMerged event of plugin failed", zap.Error(err))
 		}
 	}
 

--- a/pkg/task/yaml.go
+++ b/pkg/task/yaml.go
@@ -2,8 +2,8 @@ package task
 
 import (
 	"fmt"
-	"log/slog"
 
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/options"
 	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
 )
@@ -23,7 +23,7 @@ func readTasksYaml(
 	var result []Task
 	for idx, schemaTask := range schemaTasks {
 		if !schemaTask.Active {
-			slog.Warn("Task deactivated", "task", schemaTask.Name)
+			log.Log().Warnf("Task %s deactivated", schemaTask.Name)
 			continue
 		}
 


### PR DESCRIPTION
- `zap` supports templating while `log/slog` doesn't.