### PR TITLE
refactor: gosec warnings integer overflow

### DIFF
--- a/pkg/action/file.go
+++ b/pkg/action/file.go
@@ -90,7 +90,7 @@ func (f FileCreateFactory) Create(params map[string]any, taskPath string) (Actio
 			return nil, fmt.Errorf("parameter `mode` is of type %T not int", params["mode"])
 		}
 
-		mode = fs.FileMode(modeInt) // #nosec G115 -- no info by gosec on jow to fix this
+		mode = fs.FileMode(modeInt) // #nosec G115 -- no info by gosec on how to fix this
 	}
 
 	var overwrite bool

--- a/pkg/action/file.go
+++ b/pkg/action/file.go
@@ -90,7 +90,7 @@ func (f FileCreateFactory) Create(params map[string]any, taskPath string) (Actio
 			return nil, fmt.Errorf("parameter `mode` is of type %T not int", params["mode"])
 		}
 
-		mode = fs.FileMode(uint32(modeInt))
+		mode = fs.FileMode(modeInt) // #nosec G115 -- no info by gosec on jow to fix this
 	}
 
 	var overwrite bool

--- a/pkg/action/file.go
+++ b/pkg/action/file.go
@@ -90,7 +90,7 @@ func (f FileCreateFactory) Create(params map[string]any, taskPath string) (Actio
 			return nil, fmt.Errorf("parameter `mode` is of type %T not int", params["mode"])
 		}
 
-		mode = fs.FileMode(modeInt)
+		mode = fs.FileMode(uint32(modeInt))
 	}
 
 	var overwrite bool

--- a/pkg/server/api/work.go
+++ b/pkg/server/api/work.go
@@ -29,7 +29,7 @@ func (wh *WorkHandler) GetWorkV1(_ context.Context) (openapi.ImplResponse, error
 	}
 
 	body := openapi.GetWorkV1Response{
-		RunID: int32(run.ID),
+		RunID: int32(run.ID), // #nosec G115 -- no info by gosec on how to fix this
 		Tasks: []openapi.GetWorkV1Task{
 			{Hash: task.Hash, Name: task.TaskName},
 		},
@@ -59,6 +59,6 @@ func (wh *WorkHandler) ScheduleRunV1(_ context.Context, req openapi.ScheduleRunV
 		return openapi.Response(http.StatusInternalServerError, serverError), nil
 	}
 
-	body := openapi.ScheduleRunV1Response{RunID: int32(runID)}
+	body := openapi.ScheduleRunV1Response{RunID: int32(runID)} // #nosec G115 -- no info by gosec on how to fix this
 	return openapi.ImplResponse{Code: http.StatusCreated, Body: body}, nil
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -237,7 +237,7 @@ func mapRunResultsToTaskResults(runResults []command.RunResult) []client.ReportW
 
 		result := client.ReportWorkV1TaskResult{
 			RepositoryName: rr.RepositoryName,
-			Result:         int32(rr.Result),
+			Result:         int32(rr.Result), // #nosec G115 -- no info by gosec on how to fix this
 			TaskName:       rr.TaskName,
 		}
 		if rr.Error != nil {


### PR DESCRIPTION
```
::high file=pkg/action/file.go,line=93,col=21::G115: integer overflow conversion int -> uint32 (gosec)
::high file=pkg/worker/worker.go,line=240,col=25::G115: integer overflow conversion int -> int32 (gosec)
::high file=pkg/server/api/work.go,line=32,col=15::G115: integer overflow conversion uint -> int32 (gosec)
::high file=pkg/server/api/work.go,line=62,col=52::G115: integer overflow conversion uint -> int32 (gosec)
```