### PR TITLE
feat(command): Use default data directroy in try command

### DIFF
--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -152,7 +152,7 @@ func ExecuteRun(opts options.Opts, repositoryNames, taskFiles []string) ([]RunRe
 	cache := cache.NewJsonFile(path.Join(*opts.Config.DataDir, cache.DefaultJsonFileName))
 	taskRegistry := task.NewRegistry(opts)
 
-	gitClient, err := git.New(opts.Config)
+	gitClient, err := git.New(opts)
 	if err != nil {
 		return nil, fmt.Errorf("new git client for run: %w", err)
 	}

--- a/pkg/command/try.go
+++ b/pkg/command/try.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 
 	"github.com/wndhydrnt/saturn-bot/pkg/action"
 	saturnContext "github.com/wndhydrnt/saturn-bot/pkg/context"
@@ -27,18 +26,16 @@ type TryRunner struct {
 }
 
 func NewTryRunner(opts options.Opts, dataDir string, repositoryName string, taskFile string, taskName string) (*TryRunner, error) {
-	if dataDir == "" {
-		dataDir = path.Join(os.TempDir(), "saturn-bot")
+	if dataDir != "" {
+		// This code can set its own data dir.
+		opts.Config.DataDir = &dataDir
 	}
-
-	// This code sets its own data dir.
-	opts.Config.DataDir = &dataDir
 	err := options.Initialize(&opts)
 	if err != nil {
 		return nil, fmt.Errorf("initialize options: %w", err)
 	}
 
-	gitClient, err := git.New(opts.Config)
+	gitClient, err := git.New(opts)
 	if err != nil {
 		return nil, fmt.Errorf("new git client for try: %w", err)
 	}

--- a/pkg/command/try_test.go
+++ b/pkg/command/try_test.go
@@ -236,8 +236,9 @@ gitUserName: "unittest"`
 	require.NoError(t, err, "should parse configuration successfully")
 	opts, err := options.ToOptions(cfg)
 	require.NoError(t, err, "should convert configuration to options successfully")
+	dataDir := filepath.Join(os.TempDir(), "saturn-bot")
 
-	runner, err := command.NewTryRunner(opts, "", "git.local/unit/test", "task.yaml", "Unit Test")
+	runner, err := command.NewTryRunner(opts, dataDir, "git.local/unit/test", "task.yaml", "Unit Test")
 
 	require.NoError(t, err)
 	assert.NotNil(t, runner.ApplyActionsFunc)
@@ -248,5 +249,8 @@ gitUserName: "unittest"`
 	assert.Equal(t, "git.local/unit/test", runner.RepositoryName)
 	assert.Equal(t, "task.yaml", runner.TaskFile)
 	assert.Equal(t, "Unit Test", runner.TaskName)
-	assert.DirExists(t, filepath.Join(os.TempDir(), "saturn-bot"), "creates data directory because an empty value has been passed to NewTryRunner()")
+	assert.DirExists(t, dataDir, "creates data directory because an empty value has been passed to NewTryRunner()")
+	// Make sure to remove the directory to avoid false-positives
+	err = os.RemoveAll(dataDir)
+	require.NoError(t, err)
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wndhydrnt/saturn-bot/pkg/config"
 	"github.com/wndhydrnt/saturn-bot/pkg/host"
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
+	"github.com/wndhydrnt/saturn-bot/pkg/options"
 )
 
 type BranchModifiedError struct {
@@ -62,22 +63,22 @@ type Git struct {
 	userName         string
 }
 
-func New(cfg config.Configuration) (*Git, error) {
-	envVars, err := createGitEnvVars(cfg)
+func New(opts options.Opts) (*Git, error) {
+	envVars, err := createGitEnvVars(opts.Config)
 	if err != nil {
 		return nil, fmt.Errorf("create git auth env vars: %w", err)
 	}
 
 	return &Git{
-		cloneOpts:        cfg.GitCloneOptions,
-		dataDir:          *cfg.DataDir,
-		defaultCommitMsg: cfg.GitCommitMessage,
+		cloneOpts:        opts.Config.GitCloneOptions,
+		dataDir:          opts.DataDir(),
+		defaultCommitMsg: opts.Config.GitCommitMessage,
 		EnvVars:          envVars,
 		CmdExec:          execCmd,
-		gitPath:          cfg.GitPath,
-		gitUrl:           cfg.GitUrl,
-		userEmail:        cfg.GitUserEmail(),
-		userName:         cfg.GitUserName(),
+		gitPath:          opts.Config.GitPath,
+		gitUrl:           opts.Config.GitUrl,
+		userEmail:        opts.Config.GitUserEmail(),
+		userName:         opts.Config.GitUserName(),
 	}, nil
 }
 

--- a/pkg/host/github.go
+++ b/pkg/host/github.go
@@ -553,7 +553,7 @@ func (g *GitHubHost) CreateFromName(name string) (Repository, error) {
 		return nil, fmt.Errorf("get github repository: %w", err)
 	}
 
-	return &GitHubRepository{repo: repo}, nil
+	return &GitHubRepository{client: g.client, repo: repo}, nil
 }
 
 func (g *GitHubHost) ListRepositories(since *time.Time, result chan []Repository, errChan chan error) {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -112,10 +112,6 @@ func createHostsFromConfig(cfg config.Configuration) ([]host.Host, error) {
 func Initialize(opts *Opts) error {
 	sLog.InitLog(opts.Config.LogFormat, opts.Config.LogLevel, opts.Config.GitLogLevel)
 
-	if opts.Config.DataDir == nil {
-		return fmt.Errorf("missing dataDir configuration setting")
-	}
-
 	var dataDir string
 	if opts.Config.DataDir == nil {
 		homeDir, err := os.UserHomeDir()


### PR DESCRIPTION
- Use `options.Opts` in `command/try.go`
- Use `options.Opts` in `git/git.go`