### PR TITLE
fix(command): Get data directory via options in run command to fix nil-pointer

### DIFF
--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -149,7 +149,7 @@ func ExecuteRun(opts options.Opts, repositoryNames, taskFiles []string) ([]RunRe
 		return nil, fmt.Errorf("initialize options: %w", err)
 	}
 
-	cache := cache.NewJsonFile(path.Join(*opts.Config.DataDir, cache.DefaultJsonFileName))
+	cache := cache.NewJsonFile(path.Join(opts.DataDir(), cache.DefaultJsonFileName))
 	taskRegistry := task.NewRegistry(opts)
 
 	gitClient, err := git.New(opts)
@@ -162,7 +162,7 @@ func ExecuteRun(opts options.Opts, repositoryNames, taskFiles []string) ([]RunRe
 		DryRun: opts.Config.DryRun,
 		Hosts:  opts.Hosts,
 		Processor: &processor.Processor{
-			DataDir: *opts.Config.DataDir,
+			DataDir: opts.DataDir(),
 			Git:     gitClient,
 		},
 		TaskRegistry: taskRegistry,


### PR DESCRIPTION
Fixes nil pointer if data directory isn't set explicitly:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10125584c]

goroutine 1 [running]:
github.com/wndhydrnt/saturn-bot/pkg/command.ExecuteRun({{0x10225bd80, 0x6, 0x6}, {0x0, 0x1, {0x0, 0x0}, {0x1400013ecc0, 0x2, 0x2}, ...}, ...}, ...)
	/Users/markus/dev/workspace/github.com/wndhydrnt/saturn-bot/pkg/command/run.go:152 +0xac
github.com/wndhydrnt/saturn-bot/cmd.createRunCommand.func1(0x140000f6308, {0x140003630b0, 0x1, 0x3})
	/Users/markus/dev/workspace/github.com/wndhydrnt/saturn-bot/cmd/run.go:63 +0x1b8
github.com/spf13/cobra.(*Command).execute(0x140000f6308, {0x14000363020, 0x3, 0x3})
	/Users/markus/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0x828
github.com/spf13/cobra.(*Command).ExecuteC(0x10225f900)
	/Users/markus/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/markus/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/wndhydrnt/saturn-bot/cmd.Execute()
	/Users/markus/dev/workspace/github.com/wndhydrnt/saturn-bot/cmd/root.go:30 +0x128
main.main()
	/Users/markus/dev/workspace/github.com/wndhydrnt/saturn-bot/main.go:10 +0x1c
```