### PR TITLE
fix(log): Log message and error concatenated at the end of a run

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ func handleError(err error, out io.Writer) {
 		log.Log().Error("Configuration file contains errors:")
 		fmt.Fprintf(out, "%s\n", validationError.Error())
 	} else {
-		log.Log().Error("command failed", "error", err)
+		log.Log().Errorf("command failed: %v", err)
 	}
 
 	os.Exit(1)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -193,6 +193,7 @@ func newConfig(format config.ConfigurationLogFormat) zap.Config {
 
 	if encoderFormat == "console" {
 		zapCfg.DisableCaller = true
+		zapCfg.DisableStacktrace = true
 		zapCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	}


### PR DESCRIPTION
Also disables stack traces when log format is `console`. They aren't helpful and too distracting.