### PR TITLE
fix(action): line* actions fail if temp directory and data directory aren't on the same device

### DIFF
--- a/pkg/action/line_in_file.go
+++ b/pkg/action/line_in_file.go
@@ -178,7 +178,7 @@ func (a *lineInsert) Apply(_ context.Context) error {
 		}
 
 		defer source.Close()
-		target, err := os.CreateTemp("", "*")
+		target, err := os.CreateTemp(filepath.Dir(path), "*")
 		if err != nil {
 			return fmt.Errorf("create temporary file: %w", err)
 		}
@@ -374,7 +374,7 @@ func forEachLine(filePath string, f func(line []byte) ([]byte, error)) error {
 	}
 
 	defer source.Close()
-	target, err := os.CreateTemp("", "*")
+	target, err := os.CreateTemp(filepath.Dir(filePath), "*")
 	if err != nil {
 		return fmt.Errorf("create temporary file: %w", err)
 	}


### PR DESCRIPTION
`os.Remove()` doesn't work if data directory and `/tmp` aren't on the same device.
Create the temporary file in the data directory.