### PR TITLE
feat(command): Align args and flags of command "try" with "run"

### DIFF
--- a/cmd/try.go
+++ b/cmd/try.go
@@ -10,16 +10,16 @@ import (
 var (
 	tryCommandHelp = `Try out a task locally.
 
-"try" verifies that all filters and that actions modify files
+"try" verifies that all filters match and that actions modify files
 in a repository.
+
+Use this command during local development of a task to try it out
+and iterate frequently.
 
 It first executes all filters against the given repository and
 provides feedback on whether they match or not.
 If all filters match, it clones the repository, applies all
 actions and provides feedback on whether files have changed or not.
-
-Use this command during local development of a task to try it out
-and iterate frequently.
 
 Examples:
 
@@ -29,34 +29,34 @@ repository "github.com/wndhydrnt/saturn-bot-example".
 saturn-bot try \
   --config config.yaml \
   --repository github.com/wndhydrnt/saturn-bot-example \
-  --task-file task.yaml
+  task.yaml
 
-Try task "example" in "task.yaml" against
+Try task with name "example" in "task.yaml" against
 repository "github.com/wndhydrnt/saturn-bot-example".
 
 saturn-bot try \
   --config config.yaml \
   --repository github.com/wndhydrnt/saturn-bot-example \
-  --task-file task.yaml \
-  --task-name example`
+  --task-name example \
+  task.yaml`
 )
 
 func createTryCommand() *cobra.Command {
 	var dataDir string
 	var repository string
-	var taskFile string
 	var taskName string
 
 	cmd := &cobra.Command{
-		Use:   "try",
+		Use:   "try FILE",
 		Short: "Try out a task locally",
 		Long:  tryCommandHelp,
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg, err := config.Read(cfgFile)
 			handleError(err, cmd.ErrOrStderr())
 			opts, err := options.ToOptions(cfg)
 			handleError(err, cmd.ErrOrStderr())
-			runner, err := command.NewTryRunner(opts, dataDir, repository, taskFile, taskName)
+			runner, err := command.NewTryRunner(opts, dataDir, repository, args[0], taskName)
 			if err != nil {
 				handleError(err, cmd.ErrOrStderr())
 			}
@@ -68,7 +68,6 @@ func createTryCommand() *cobra.Command {
 	cmd.Flags().StringVar(&cfgFile, "config", "", "Path to config file.")
 	cmd.Flags().StringVar(&dataDir, "data-dir", "", "Path to directory to clone the repository.")
 	cmd.Flags().StringVar(&repository, "repository", "", "Name of the repository to test against.")
-	cmd.Flags().StringVar(&taskFile, "task-file", "", "Path to the task file to try out.")
 	cmd.Flags().StringVar(&taskName, "task-name", "", `If set, try only the task that matches the name.
 Useful if a task file contains multiple tasks.`)
 	return cmd

--- a/docs/commands/try.md
+++ b/docs/commands/try.md
@@ -3,16 +3,16 @@
 ```{.text mdox-exec="./saturn-bot try --help" title="try"}
 Try out a task locally.
 
-"try" verifies that all filters and that actions modify files
+"try" verifies that all filters match and that actions modify files
 in a repository.
+
+Use this command during local development of a task to try it out
+and iterate frequently.
 
 It first executes all filters against the given repository and
 provides feedback on whether they match or not.
 If all filters match, it clones the repository, applies all
 actions and provides feedback on whether files have changed or not.
-
-Use this command during local development of a task to try it out
-and iterate frequently.
 
 Examples:
 
@@ -22,26 +22,25 @@ repository "github.com/wndhydrnt/saturn-bot-example".
 saturn-bot try \
   --config config.yaml \
   --repository github.com/wndhydrnt/saturn-bot-example \
-  --task-file task.yaml
+  task.yaml
 
-Try task "example" in "task.yaml" against
+Try task with name "example" in "task.yaml" against
 repository "github.com/wndhydrnt/saturn-bot-example".
 
 saturn-bot try \
   --config config.yaml \
   --repository github.com/wndhydrnt/saturn-bot-example \
-  --task-file task.yaml \
-  --task-name example
+  --task-name example \
+  task.yaml
 
 Usage:
-  saturn-bot try [flags]
+  saturn-bot try FILE [flags]
 
 Flags:
       --config string       Path to config file.
       --data-dir string     Path to directory to clone the repository.
   -h, --help                help for try
       --repository string   Name of the repository to test against.
-      --task-file string    Path to the task file to try out.
       --task-name string    If set, try only the task that matches the name.
                             Useful if a task file contains multiple tasks.
 ```


### PR DESCRIPTION
Use the same interface to quickly swap "try" with "run".