### PR TITLE
fix(command): No information about which task failed

### DIFF
--- a/pkg/command/processormock_test.go
+++ b/pkg/command/processormock_test.go
@@ -17,6 +17,7 @@ import (
 	processor "github.com/wndhydrnt/saturn-bot/pkg/processor"
 	task "github.com/wndhydrnt/saturn-bot/pkg/task"
 	gomock "go.uber.org/mock/gomock"
+	zap "go.uber.org/zap"
 )
 
 //go:generate mockgen -package command_test -source ../processor/processor.go -destination processormock_test.go -write_generate_directive
@@ -45,16 +46,16 @@ func (m *MockRepositoryTaskProcessor) EXPECT() *MockRepositoryTaskProcessorMockR
 }
 
 // Process mocks base method.
-func (m *MockRepositoryTaskProcessor) Process(ctx context.Context, dryRun bool, repo host.Repository, task task.Task, doFilter bool) (processor.Result, error) {
+func (m *MockRepositoryTaskProcessor) Process(ctx context.Context, dryRun bool, repo host.Repository, task task.Task, doFilter bool, logger *zap.SugaredLogger) (processor.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Process", ctx, dryRun, repo, task, doFilter)
+	ret := m.ctrl.Call(m, "Process", ctx, dryRun, repo, task, doFilter, logger)
 	ret0, _ := ret[0].(processor.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Process indicates an expected call of Process.
-func (mr *MockRepositoryTaskProcessorMockRecorder) Process(ctx, dryRun, repo, task, doFilter any) *gomock.Call {
+func (mr *MockRepositoryTaskProcessorMockRecorder) Process(ctx, dryRun, repo, task, doFilter, logger any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*MockRepositoryTaskProcessor)(nil).Process), ctx, dryRun, repo, task, doFilter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*MockRepositoryTaskProcessor)(nil).Process), ctx, dryRun, repo, task, doFilter, logger)
 }

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wndhydrnt/saturn-bot/pkg/options"
 	"github.com/wndhydrnt/saturn-bot/pkg/processor"
 	"github.com/wndhydrnt/saturn-bot/pkg/task"
+	"go.uber.org/zap"
 )
 
 var (
@@ -102,10 +103,16 @@ func (r *Run) Run(repositoryNames, taskFiles []string) ([]RunResult, error) {
 						RepositoryName: repo.FullName(),
 						TaskName:       t.SourceTask().Name,
 					}
-					result.Result, result.Error = r.Processor.Process(ctx, r.DryRun, repo, t, doFilter)
+					logger := log.Log().
+						WithOptions(zap.Fields(
+							log.FieldDryRun(r.DryRun),
+							log.FieldRepo(repo.FullName()),
+							log.FieldTask(t.SourceTask().Name),
+						))
+					result.Result, result.Error = r.Processor.Process(ctx, r.DryRun, repo, t, doFilter, logger)
 					if result.Error != nil {
 						success = false
-						log.Log().Errorw("Task failed", "error", result.Error)
+						logger.Errorw("Task failed", "error", result.Error)
 					}
 
 					results = append(results, result)

--- a/pkg/command/run_test.go
+++ b/pkg/command/run_test.go
@@ -170,10 +170,10 @@ func TestExecuteRunner_Run(t *testing.T) {
 	var ctx = reflect.TypeOf((*context.Context)(nil)).Elem()
 	var anyTask task.Task = &task.Wrapper{}
 	procMock.EXPECT().
-		Process(gomock.AssignableToTypeOf(ctx), false, repo, gomock.AssignableToTypeOf(anyTask), true).
+		Process(gomock.AssignableToTypeOf(ctx), false, repo, gomock.AssignableToTypeOf(anyTask), true, gomock.Any()).
 		Return(processor.ResultNoChanges, nil)
 	procMock.EXPECT().
-		Process(gomock.AssignableToTypeOf(ctx), false, repoWithPr, gomock.AssignableToTypeOf(anyTask), true).
+		Process(gomock.AssignableToTypeOf(ctx), false, repoWithPr, gomock.AssignableToTypeOf(anyTask), true, gomock.Any()).
 		Return(processor.ResultNoChanges, nil)
 
 	runner := &command.Run{
@@ -214,7 +214,7 @@ func TestExecuteRunner_Run_DryRun(t *testing.T) {
 	var ctx = reflect.TypeOf((*context.Context)(nil)).Elem()
 	var anyTask task.Task = &task.Wrapper{}
 	procMock.EXPECT().
-		Process(gomock.AssignableToTypeOf(ctx), true, repo, gomock.AssignableToTypeOf(anyTask), true).
+		Process(gomock.AssignableToTypeOf(ctx), true, repo, gomock.AssignableToTypeOf(anyTask), true, gomock.Any()).
 		Return(processor.ResultNoChanges, nil)
 
 	runner := &command.Run{
@@ -255,7 +255,7 @@ func TestExecuteRunner_Run_RepositoriesCLI(t *testing.T) {
 	var ctx = reflect.TypeOf((*context.Context)(nil)).Elem()
 	var anyTask task.Task = &task.Wrapper{}
 	procMock.EXPECT().
-		Process(gomock.AssignableToTypeOf(ctx), false, repo, gomock.AssignableToTypeOf(anyTask), false).
+		Process(gomock.AssignableToTypeOf(ctx), false, repo, gomock.AssignableToTypeOf(anyTask), false, gomock.Any()).
 		Return(processor.ResultNoChanges, nil)
 
 	runner := &command.Run{

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -44,7 +44,7 @@ type Processor struct {
 }
 
 type RepositoryTaskProcessor interface {
-	Process(ctx context.Context, dryRun bool, repo host.Repository, task task.Task, doFilter bool) (Result, error)
+	Process(ctx context.Context, dryRun bool, repo host.Repository, task task.Task, doFilter bool, logger *zap.SugaredLogger) (Result, error)
 }
 
 func (p *Processor) Process(
@@ -53,13 +53,8 @@ func (p *Processor) Process(
 	repo host.Repository,
 	task task.Task,
 	doFilter bool,
+	logger *zap.SugaredLogger,
 ) (Result, error) {
-	logger := log.Log().
-		WithOptions(zap.Fields(
-			log.FieldDryRun(dryRun),
-			log.FieldRepo(repo.FullName()),
-			log.FieldTask(task.SourceTask().Name),
-		))
 	logger.Debug("Processing repository")
 	task.SetLogger(logger)
 	if task.HasReachMaxOpenPRs() {

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -15,6 +15,11 @@ import (
 	"github.com/wndhydrnt/saturn-bot/pkg/task"
 	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+)
+
+var (
+	testLogger = zap.NewNop().Sugar()
 )
 
 type trueFilter struct{}
@@ -77,7 +82,7 @@ func TestProcessor_Process_CreatePullRequestLocalChanges(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrCreated, result)
@@ -110,7 +115,7 @@ func TestProcessor_Process_CreatePullRequestRemoteChanges(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrCreated, result)
@@ -128,7 +133,7 @@ func TestProcessor_Process_PullRequestClosedAndMergeOnceActive(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrClosedBefore, result)
@@ -147,7 +152,7 @@ func TestProcessor_Process_PullRequestMergedAndMergeOnceActive(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrMergedBefore, result)
@@ -166,7 +171,7 @@ func TestProcessor_Process_CreateOnly(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrOpen, result)
@@ -202,7 +207,7 @@ func TestProcessor_Process_ClosePullRequestIfChangesExistInBaseBranch(t *testing
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrClosed, result)
@@ -239,7 +244,7 @@ func TestProcessor_Process_MergePullRequest(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrMerged, result)
@@ -273,7 +278,7 @@ func TestProcessor_Process_MergePullRequest_FailedMergeChecks(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultChecksFailed, result)
@@ -312,7 +317,7 @@ func TestProcessor_Process_MergePullRequest_AutoMergeAfter(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultAutoMergeTooEarly, result)
@@ -351,7 +356,7 @@ func TestProcessor_Process_MergePullRequest_MergeConflict(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultConflict, result)
@@ -403,7 +408,7 @@ func TestProcessor_Process_UpdatePullRequest(t *testing.T) {
 	ctx = context.WithValue(ctx, sContext.RunDataKey{}, map[string]string{"Greeting": "Hello", "TaskName": "other"})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(ctx, false, repo, tw, true)
+	result, err := p.Process(ctx, false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrOpen, result)
@@ -435,7 +440,7 @@ func TestProcessor_Process_NoChanges(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultNoChanges, result)
@@ -487,7 +492,7 @@ The commit(s) that modified the pull request:
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultBranchModified, result)
@@ -527,7 +532,7 @@ func TestProcessor_Process_ForceRebaseByUser(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrOpen, result)
@@ -541,7 +546,7 @@ func TestProcessor_Process_ChangeLimit(t *testing.T) {
 	tw.IncChangeLimitCount()
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultSkip, result)
@@ -555,7 +560,7 @@ func TestProcessor_Process_MaxOpenPRs(t *testing.T) {
 	tw.IncOpenPRsCount()
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultSkip, result)
@@ -569,7 +574,7 @@ func TestProcessor_Process_FilterNotMatching(t *testing.T) {
 	tw.AddFilters(&falseFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultNoMatch, result)
@@ -582,7 +587,7 @@ func TestProcessor_Process_NoFilters(t *testing.T) {
 	tw := &task.Wrapper{Task: schema.Task{Name: "unittest"}}
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultNoMatch, result)
@@ -606,7 +611,7 @@ func TestProcessor_Process_AutoCloseAfter_Close(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrClosed, result)
@@ -635,7 +640,7 @@ func TestProcessor_Process_AutoCloseAfter_NotTimeYet(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, err := p.Process(context.Background(), false, repo, tw, true, testLogger)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrOpen, result)


### PR DESCRIPTION
- Pass logger with fields to `processor`.
- Use the logger to log the `Task failed` log message.