### PR TITLE
fix(log): Work around warning of zap when `logLevel` is `error`

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Version  = "dev"
+	Version  = "v0.0.0-dev"
 	Hash     = ""
 	DateTime = ""
 )


### PR DESCRIPTION
Source of the error is the extra logger of the `git` package. Levels between default logger and git logger can differ, but zap supports increasing the level only.
For example, it is not possible to decrease the level of the default logger from `error` to `warn`.
A decrease is necessary because the git logger is created by cloning the default logger.

Instead, check the levels and only increase when necessary.

Fixes #80 