### PR TITLE
fix(config): Fail early if no GitHub token or GitLab token has been defined

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,10 @@ func Read(cfgFile string) (cfg Configuration, err error) {
 		return cfg, fmt.Errorf("schema validation failed: %w", err)
 	}
 
+	if cfg.GithubToken == nil && cfg.GitlabToken == nil {
+		return cfg, fmt.Errorf("no GitHub token or GitLab token configured")
+	}
+
 	if cfg.GitAuthor != "" {
 		_, err = mail.ParseAddress(cfg.GitAuthor)
 		if err != nil {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -29,8 +29,7 @@ func Log() *zap.SugaredLogger {
 
 func init() {
 	// Ensure that a logger is always present
-	logger := zap.Must(zap.NewProduction())
-	DefaultLogger = logger.Sugar()
+	InitLog("auto", "error", "error")
 }
 
 type hclogAdapter struct {

--- a/pkg/ptr/ptr.go
+++ b/pkg/ptr/ptr.go
@@ -1,9 +1,12 @@
+// ptr provides functions to convert from/to pointers.
 package ptr
 
+// To converts a value to pointer.
 func To[T any](v T) *T {
 	return &v
 }
 
+// From dereferences a pointer.
 func From[T any](v *T) T {
 	return *v
 }

--- a/pkg/ptr/ptr.go
+++ b/pkg/ptr/ptr.go
@@ -1,0 +1,9 @@
+package ptr
+
+func To[T any](v T) *T {
+	return &v
+}
+
+func From[T any](v *T) T {
+	return *v
+}


### PR DESCRIPTION
- Check for the presence of the tokens during parsing of configuration.
- Initialize logger via the `InitLog()` function. Prints the error message in the format detected by the code, which makes it easier to read for the user.

Fixes #85.