### PR TITLE
feat(filter): Specify multiple expressions in filter xpath

### DIFF
--- a/docs/task/filters/xpath.md
+++ b/docs/task/filters/xpath.md
@@ -7,7 +7,7 @@ Matches if every query returns at least one XML node.
 
 ### `expressions`
 
-List of XPath expressions to use for querying the XML document.
+List of XPath expressions to query the XML document.
 
 Use an online tool such as [XPather](http://xpather.com/) to test the expression.
 

--- a/docs/task/filters/xpath.md
+++ b/docs/task/filters/xpath.md
@@ -1,22 +1,22 @@
 # xpath
 
-Downloads an XML document from a repository and queries it via an XPath expression.
-Matches if the query returns at least one XML node.
+Downloads an XML document from a repository and queries it via one or more XPath expressions.
+Matches if every query returns at least one XML node.
 
 ## Parameters
 
-### `expression`
+### `expressions`
 
-The XPath expression to use for querying the XML document.
+List of XPath expressions to use for querying the XML document.
 
 Use an online tool such as [XPather](http://xpather.com/) to test the expression.
 
 The [XPath cheatsheet](https://devhints.io/xpath) can be a valuable reference.
 
-| Name     | Value    |
-| -------- | -------- |
-| Type     | `string` |
-| Required | **Yes**  |
+| Name     | Value      |
+| -------- | ---------- |
+| Type     | `string[]` |
+| Required | **Yes**    |
 
 ### `path`
 
@@ -34,7 +34,19 @@ Path to the XML document in a repository.
 filters:
   - filter: xpath
     params:
-      expression: '/project/dependencies/dependency/artifactId[text()="kotlin-stdlib"]'
+      expressions: ['/project/dependencies/dependency/artifactId[text()="kotlin-stdlib"]']
+      path: pom.xml
+```
+
+```yaml
+# Match if the file pom.xml defines a dependency
+# on the library kotlin-stdlib and kotlinx.coroutines.
+filters:
+  - filter: xpath
+    params:
+      expressions:
+        - '/project/dependencies/dependency/artifactId[text()="kotlin-stdlib"]'
+        - '/project/dependencies/dependency/artifactId[text()="kotlinx-coroutines-core"]'
       path: pom.xml
 ```
 
@@ -43,7 +55,7 @@ filters:
 filters:
   - filter: xpath
     params:
-      expression: '/project/dependencies/dependency/artifactId[text()="kotlin-stdlib"]'
+      expressions: ['/project/dependencies/dependency/artifactId[text()="kotlin-stdlib"]']
       path: pom.xml
     reverse: true
 ```

--- a/pkg/filter/xpath_test.go
+++ b/pkg/filter/xpath_test.go
@@ -1,47 +1,54 @@
 package filter_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	sbcontext "github.com/wndhydrnt/saturn-bot/pkg/context"
 	"github.com/wndhydrnt/saturn-bot/pkg/filter"
 	"github.com/wndhydrnt/saturn-bot/pkg/host"
-	"go.uber.org/mock/gomock"
+	"github.com/wndhydrnt/saturn-bot/pkg/params"
 )
 
 func TestXpathFactory_Create(t *testing.T) {
 	fac := filter.XpathFactory{}
+	testCases := []testCase{
+		{
+			name:             "errors when parameter expressions is not set",
+			factory:          fac,
+			params:           params.Params{"path": "pom.xml"},
+			wantFactoryError: "required parameter `expressions` not set",
+		},
+		{
+			name:             "errors when parameter expressions does not contain strings",
+			factory:          fac,
+			params:           params.Params{"expressions": []any{"abc", 1}, "path": "pom.xml"},
+			wantFactoryError: "parameter `expressions[1]` is of type int not string",
+		},
+		{
+			name:             "errors when parameter expressions contains an invalid XPath expression",
+			factory:          fac,
+			params:           params.Params{"expressions": []any{"///project"}, "path": "pom.xml"},
+			wantFactoryError: "compile `expressions[0]` XPath expression: expression must evaluate to a node-set",
+		},
+		{
+			name:             "errors when parameter path is not set",
+			factory:          fac,
+			params:           params.Params{"expressions": []any{"//project"}},
+			wantFactoryError: "required parameter `path` not set",
+		},
+		{
+			name:             "errors when parameter path is not of type string",
+			factory:          fac,
+			params:           params.Params{"expressions": []any{"//project"}, "path": 123},
+			wantFactoryError: "parameter `path` is of type int not string",
+		},
+	}
 
-	_, err := fac.Create(map[string]any{
-		"path": "pom.xml",
-	})
-	require.EqualError(t, err, "required parameter `expression` not set")
-
-	_, err = fac.Create(map[string]any{
-		"expression": 123,
-		"path":       "pom.xml",
-	})
-	require.EqualError(t, err, "parameter `expression` is of type int not string")
-
-	_, err = fac.Create(map[string]any{
-		"expression": "///project",
-		"path":       "pom.xml",
-	})
-	require.EqualError(t, err, "invalid XPath expression: expression must evaluate to a node-set")
-
-	_, err = fac.Create(map[string]any{
-		"expression": "//project",
-	})
-	require.EqualError(t, err, "required parameter `path` not set")
-
-	_, err = fac.Create(map[string]any{
-		"expression": "//project",
-		"path":       123,
-	})
-	require.EqualError(t, err, "parameter `path` is of type int not string")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runTestCase(t, tc)
+		})
+	}
 }
 
 func TestXpath_Do(t *testing.T) {
@@ -61,80 +68,83 @@ func TestXpath_Do(t *testing.T) {
   </dependencies>
 </project>
 `
-	ctrl := gomock.NewController(t)
-	repoMock := NewMockRepository(ctrl)
-	repoMock.EXPECT().
-		GetFile("pom.xml").
-		Return(content, nil).
-		Times(2)
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, sbcontext.RepositoryKey{}, repoMock)
-
 	fac := filter.XpathFactory{}
+	testCases := []testCase{
+		{
+			name:    "returns true when expression matches a node",
+			factory: fac,
+			params: params.Params{
+				"expressions": []any{`/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]//version[starts-with(text(), "2")]`},
+				"path":        "pom.xml",
+			},
+			repoMockFunc: func(mr *MockRepository) {
+				mr.EXPECT().
+					GetFile("pom.xml").
+					Return(content, nil)
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "returns false when expression does not match any nodes",
+			factory: fac,
+			params: params.Params{
+				"expressions": []any{`/project//dependencies//dependency[artifactId/text()="kotlin-bom"]`},
+				"path":        "pom.xml",
+			},
+			repoMockFunc: func(mr *MockRepository) {
+				mr.EXPECT().
+					GetFile("pom.xml").
+					Return(content, nil)
+			},
+			wantMatch: false,
+		},
+		{
+			name:    "returns false when the repository does not contain the file",
+			factory: fac,
+			params: params.Params{
+				"expressions": []any{`/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]`},
+				"path":        "other.xml",
+			},
+			repoMockFunc: func(mr *MockRepository) {
+				mr.EXPECT().
+					GetFile("other.xml").
+					Return("", host.ErrFileNotFound)
+			},
+			wantMatch: false,
+		},
+		{
+			name:    "errors when the download of the file fails",
+			factory: fac,
+			params: params.Params{
+				"expressions": []any{`/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]`},
+				"path":        "failure.xml",
+			},
+			repoMockFunc: func(mr *MockRepository) {
+				mr.EXPECT().
+					GetFile("failure.xml").
+					Return("", errors.New("internal server error"))
+			},
+			wantFilterError: "download file from repository: internal server error",
+		},
+		{
+			name:    "returns false when the file contains invalid XML",
+			factory: fac,
+			params: params.Params{
+				"expressions": []any{`/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]`},
+				"path":        "invalid.xml",
+			},
+			repoMockFunc: func(mr *MockRepository) {
+				mr.EXPECT().
+					GetFile("invalid.xml").
+					Return("<<project>invalid</project>", nil)
+			},
+			wantMatch: false,
+		},
+	}
 
-	f, err := fac.Create(map[string]any{
-		"expression": `/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]//version[starts-with(text(), "2")]`,
-		"path":       "pom.xml",
-	})
-	require.NoError(t, err)
-	result, err := f.Do(ctx)
-
-	require.NoError(t, err)
-	require.True(t, result)
-
-	f, err = fac.Create(map[string]any{
-		"expression": `/project//dependencies//dependency[artifactId/text()="kotlin-bom"]`,
-		"path":       "pom.xml",
-	})
-	require.NoError(t, err)
-	result, err = f.Do(ctx)
-
-	require.NoError(t, err)
-	require.False(t, result)
-
-	f, err = fac.Create(map[string]any{
-		"expression": `/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]`,
-		"path":       "pom.xml",
-	})
-	require.NoError(t, err)
-	_, err = f.Do(context.Background())
-	require.EqualError(t, err, "context does not contain a repository")
-
-	repoMock.EXPECT().
-		GetFile("other.xml").
-		Return("", host.ErrFileNotFound).
-		Times(1)
-	f, err = fac.Create(map[string]any{
-		"expression": `/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]`,
-		"path":       "other.xml",
-	})
-	require.NoError(t, err)
-	result, err = f.Do(ctx)
-	require.NoError(t, err)
-	require.False(t, result)
-
-	repoMock.EXPECT().
-		GetFile("failure.xml").
-		Return("", errors.New("internal server error")).
-		Times(1)
-	f, err = fac.Create(map[string]any{
-		"expression": `/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]`,
-		"path":       "failure.xml",
-	})
-	require.NoError(t, err)
-	_, err = f.Do(ctx)
-	require.EqualError(t, err, "download file from repository: internal server error")
-
-	repoMock.EXPECT().
-		GetFile("invalid.xml").
-		Return("<<project>invalid</project>", nil).
-		Times(1)
-	f, err = fac.Create(map[string]any{
-		"expression": `/project//dependencies//dependency[artifactId/text()="kotlin-stdlib"]`,
-		"path":       "invalid.xml",
-	})
-	require.NoError(t, err)
-	_, err = f.Do(ctx)
-
-	require.EqualError(t, err, "parse XML document: XML syntax error on line 1: expected element name after <")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runTestCase(t, tc)
+		})
+	}
 }

--- a/pkg/params/params.go
+++ b/pkg/params/params.go
@@ -40,3 +40,26 @@ func (p Params) String(key string, def string) (string, error) {
 
 	return val, nil
 }
+
+func (p Params) StringSlice(key string, def []string) ([]string, error) {
+	if p[key] == nil {
+		return def, nil
+	}
+
+	rawV, ok := p[key].([]interface{})
+	if !ok {
+		return def, fmt.Errorf("parameter `%s` is of type %T not slice", key, p[key])
+	}
+
+	var vals []string
+	for idx, rawItem := range rawV {
+		v, ok := rawItem.(string)
+		if !ok {
+			return def, fmt.Errorf("parameter `%s[%d]` is of type %T not string", key, idx, rawItem)
+		}
+
+		vals = append(vals, v)
+	}
+
+	return vals, nil
+}

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -143,7 +143,7 @@ func TestRegistry_ReadAll_AllBuiltInFilters(t *testing.T) {
         path: package.json
     - filter: xpath
       params:
-        expression: "//project"
+        expressions: ["//project"]
         path: pom.xml
 `
 	tempDir, err := os.MkdirTemp("", "")
@@ -173,7 +173,7 @@ func TestRegistry_ReadAll_AllBuiltInFilters(t *testing.T) {
 		"fileContent(path=hello-world.txt,regexp=Hello World)",
 		"!file(op=and,paths=[test.txt])",
 		"jsonpath(expression=$.dependencies,path=package.json)",
-		"xpath(expression=//project,path=pom.xml)",
+		"xpath(expressions=[//project],path=pom.xml)",
 	}
 	var actualFilters []string
 	for _, a := range task.Filters() {


### PR DESCRIPTION
- More effiecient because a file doesn't need to be downloaded multiple times.
- More compact because only one entry in `filters` is needed to query via multiple expressions.
- Also refactors tests to use table-driven tests.