### PR TITLE
feat(task): Execute repository filter first

### DIFF
--- a/docs/task/filters/repository.md
+++ b/docs/task/filters/repository.md
@@ -4,8 +4,8 @@ Match a repository if its host, owner and name match.
 
 !!! note
 
-    The repository filter is very cheap to execute because it doesn't make additional API calls.
-    saturn-bot always executes it before all other filters of a task.
+    The repository filter is cheap to execute because it doesn't make additional API calls.
+    saturn-bot executes it before all other filters of a task.
 
 ## Parameters
 

--- a/docs/task/filters/repository.md
+++ b/docs/task/filters/repository.md
@@ -2,6 +2,11 @@
 
 Match a repository if its host, owner and name match.
 
+!!! note
+
+    The repository filter is very cheap to execute because it doesn't make additional API calls.
+    saturn-bot always executes it before all other filters of a task.
+
 ## Parameters
 
 ### `host`

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	htmlTemplate "html/template"
+	"slices"
 	"time"
 
 	"github.com/gosimple/slug"
@@ -70,6 +71,27 @@ func createFiltersForTask(filterDefs []schema.Filter, factories options.FilterFa
 
 		result = append(result, fl)
 	}
+
+	slices.SortStableFunc(result, func(a filter.Filter, b filter.Filter) int {
+		_, aOk := a.(*filter.Repository)
+		_, bOk := b.(*filter.Repository)
+		// Both of type Repository. Keep order.
+		if aOk && bOk {
+			return 0
+		}
+		// None of type Repository. Keep order.
+		if !aOk && !bOk {
+			return 0
+		}
+		// a is of type Repository.
+		// Put it before b.
+		if aOk && !bOk {
+			return -1
+		}
+		// b is of type Repository.
+		// Put it before a.
+		return 1
+	})
 
 	return result, nil
 }


### PR DESCRIPTION
Filter is cheapest to execute because it doesn't make additional API calls.
It should be executed first, no matter where the user puts it in the list of filters.