### PR TITLE
fix(host): Do not update assignees or reviewers when task does not define them

### DIFF
--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -47,6 +47,22 @@ active: true
 active: false
 ```
 
+## assignees
+
+[json-path:../../pkg/task/schema/task.schema.json:$.properties.assignees.description]
+
+!!! note
+
+    saturn-bot doesn't remove assignees when the value is set back to an empty list.
+
+Examples
+
+```yaml title="Set assignees"
+assignees:
+  - ellie
+  - joel
+```
+
 ## autoCloseAfter
 
 [json-path:../../pkg/task/schema/task.schema.json:$.properties.autoCloseAfter.description]
@@ -211,6 +227,22 @@ prTitle: "feat: Custom title"
 
 ```yaml title="Use a template variable"
 prTitle: "Apply task {{.TaskName}}"
+```
+
+## reviewers
+
+[json-path:../../pkg/task/schema/task.schema.json:$.properties.reviewers.description]
+
+!!! note
+
+    saturn-bot doesn't remove reviewers when the value is set back to an empty list.
+
+Examples
+
+```yaml title="Set reviewers"
+reviewers:
+  - ellie
+  - joel
 ```
 
 ## schedule

--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -53,7 +53,8 @@ active: false
 
 !!! note
 
-    saturn-bot doesn't remove assignees when the value is set back to an empty list.
+    If the task previously defined assignees and the list is set back to empty
+    then saturn-bot doesn't remove the assignees from a pull request.
 
 Examples
 
@@ -235,7 +236,8 @@ prTitle: "Apply task {{.TaskName}}"
 
 !!! note
 
-    saturn-bot doesn't remove reviewers when the value is set back to an empty list.
+    If the task previously defined reviewers and the list is set back to empty
+    then saturn-bot doesn't remove the reviewers from a pull request.
 
 Examples
 

--- a/pkg/host/github_test.go
+++ b/pkg/host/github_test.go
@@ -676,14 +676,6 @@ _This pull request has been created by [saturn-bot](https://github.com/wndhydrnt
 			"body":  body,
 		}).
 		Reply(200)
-	gock.New("https://api.github.com").
-		Get("/repos/unit/test/pulls/987/reviews").
-		MatchParams(map[string]string{
-			"page":     "1",
-			"per_page": "20",
-		}).
-		Reply(200).
-		JSON([]*github.PullRequestReview{})
 	pr := &github.PullRequest{
 		Body:   github.String("old body"),
 		Number: github.Int(987),
@@ -723,14 +715,6 @@ func TestGitHubRepository_UpdatePullRequest_NoUpdate(t *testing.T) {
 _This pull request has been created by [saturn-bot](https://github.com/wndhydrnt/saturn-bot)_ 🪐🤖.
 `
 	defer gock.Off()
-	gock.New("https://api.github.com").
-		Get("/repos/unit/test/pulls/987/reviews").
-		MatchParams(map[string]string{
-			"page":     "1",
-			"per_page": "20",
-		}).
-		Reply(200).
-		JSON([]*github.PullRequestReview{})
 	pr := &github.PullRequest{
 		Body:   github.String(body),
 		Number: github.Int(987),
@@ -782,14 +766,6 @@ _This pull request has been created by [saturn-bot](https://github.com/wndhydrnt
 			"assignees": []string{"y", "z"},
 		}).
 		Reply(200)
-	gock.New("https://api.github.com").
-		Get("/repos/unit/test/pulls/987/reviews").
-		MatchParams(map[string]string{
-			"page":     "1",
-			"per_page": "20",
-		}).
-		Reply(200).
-		JSON([]*github.PullRequestReview{})
 	pr := &github.PullRequest{
 		Assignees: []*github.User{
 			{Login: github.String("a")},

--- a/pkg/host/gitlab_test.go
+++ b/pkg/host/gitlab_test.go
@@ -615,10 +615,8 @@ func TestGitLabRepository_UpdatePullRequest(t *testing.T) {
 		Put("/api/v4/projects/123/merge_requests/987").
 		MatchType("json").
 		JSON(map[string]any{
-			"title":        "New PR Title",
-			"description":  "New PR Body\n\n---\n\n**Auto-merge:** Disabled. Merge this manually.\n\n**Ignore:** This PR will be recreated if closed.\n\n---\n\n- [ ] If you want to rebase this PR, check this box\n\n---\n\n_This pull request has been created by [saturn-bot](https://github.com/wndhydrnt/saturn-bot)_ 🪐🤖.\n",
-			"assignee_ids": nil,
-			"reviewer_ids": nil,
+			"title":       "New PR Title",
+			"description": "New PR Body\n\n---\n\n**Auto-merge:** Disabled. Merge this manually.\n\n**Ignore:** This PR will be recreated if closed.\n\n---\n\n- [ ] If you want to rebase this PR, check this box\n\n---\n\n_This pull request has been created by [saturn-bot](https://github.com/wndhydrnt/saturn-bot)_ 🪐🤖.\n",
 		}).
 		Reply(200).
 		JSON(map[string]string{})
@@ -683,8 +681,6 @@ func TestGitLabRepository_UpdatePullRequest_UpdatedAssigneesReviewers(t *testing
 		Put("/api/v4/projects/123/merge_requests/987").
 		MatchType("json").
 		JSON(map[string]any{
-			"title":        "PR Title",
-			"description":  gitlabMergeRequestBody,
 			"assignee_ids": []int{25, 26, 1},
 			"reviewer_ids": []int{5, 24},
 		}).


### PR DESCRIPTION
Before, saturn-bot would remove assignees and reviewers added by a human or other automation.

Comes with the caveat that explicitly setting the list back to empty doesn't remove assignees or reviewers.
That can be fixed once https://github.com/omissis/go-jsonschema/issues/231 is resolved.