### PR TITLE
feat(command): Run command sends metrics to Prometheus Pushgateway

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,15 +200,15 @@ Set to `ssh` to clone repositories via SSH.
 | Type    | `string`                         |
 | Values  | `debug`, `error`, `info`, `warn` |
 
-## pushgatewayUrl
+## prometheusPushgatewayUrl
 
-[json-path:../pkg/config/config.schema.json:$.properties.pushgatewayUrl.description]
+[json-path:../pkg/config/config.schema.json:$.properties.prometheusPushgatewayUrl.description]
 
-| Name    | Value                       |
-| ------- | --------------------------- |
-| Default | -                           |
-| Env Var | `SATURN_BOT_PUSHGATEWAYURL` |
-| Type    | `string`                    |
+| Name    | Value                                 |
+| ------- | ------------------------------------- |
+| Default | -                                     |
+| Env Var | `SATURN_BOT_PROMETHEUSPUSHGATEWAYURL` |
+| Type    | `string`                              |
 
 ## pythonPath
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,6 +200,16 @@ Set to `ssh` to clone repositories via SSH.
 | Type    | `string`                         |
 | Values  | `debug`, `error`, `info`, `warn` |
 
+## pushgatewayUrl
+
+[json-path:../pkg/config/config.schema.json:$.properties.pushgatewayUrl.description]
+
+| Name    | Value                       |
+| ------- | --------------------------- |
+| Default | -                           |
+| Env Var | `SATURN_BOT_PUSHGATEWAYURL` |
+| Type    | `string`                    |
+
 ## pythonPath
 
 [json-path:../pkg/config/config.schema.json:$.properties.pythonPath.description]

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -2,19 +2,38 @@
 title: Metrics
 ---
 
-[saturn-bot run](../commands/run.md) can optionally push metrics
-to a [Prometheus Pushgateway](https://github.com/prometheus/pushgateway).
+[saturn-bot run](../commands/run.md) pushes metrics
+to a [Prometheus Pushgateway](https://github.com/prometheus/pushgateway)
+if [prometheusPushgatewayUrl](../configuration.md#prometheuspushgatewayurl) is set.
+
+The `job` label added to all metrics is `saturn-bot`.
 
 The following metrics exist:
 
-## `saturn_bot_http_client_requests_total`
+## `http_client_requests_total`
 
-## `saturn_bot_run_finish_time_seconds`
+Total number of requests sent via HTTP clients.
 
-## `saturn_bot_run_start_time_seconds`
+This metric includes HTTP requests sent to GitHub or GitLab.
 
-## `saturn_bot_run_task_success`
+Useful to understand how much load saturn-bot puts on an API.
 
-Status of the last run of a task. 1 indicates a successful run. 0 indicates a failed run.
+## `run_finish_time_seconds`
 
-Use this metric to alert if a task fails.
+Last unix time when the run finished.
+
+Use this metric together with [`run_start_time_seconds`](#run_start_time_seconds)
+to understand how long the execution of `saturn-bot run` took.
+
+## `run_start_time_seconds`
+
+Last unix time when the run started.
+
+Use this metric together with [`run_finish_time_seconds`](#run_finish_time_seconds)
+to understand how long the execution of `saturn-bot run` took.
+
+## `run_task_success`
+
+Status of the last run of a task. 1 indicates success. 0 indicates failure.
+
+Use this metric to alert that a task has failed.

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -1,0 +1,20 @@
+---
+title: Metrics
+---
+
+[saturn-bot run](../commands/run.md) can optionally push metrics
+to a [Prometheus Pushgateway](https://github.com/prometheus/pushgateway).
+
+The following metrics exist:
+
+## `saturn_bot_http_client_requests_total`
+
+## `saturn_bot_run_finish_time_seconds`
+
+## `saturn_bot_run_start_time_seconds`
+
+## `saturn_bot_run_task_success`
+
+Status of the last run of a task. 1 indicates a successful run. 0 indicates a failed run.
+
+Use this metric to alert if a task fails.

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/ncruces/go-sqlite3/gormlite v0.16.3
 	github.com/ohler55/ojg v1.24.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/prometheus/client_golang v1.20.2
+	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/common v0.55.0
 	github.com/robfig/cron v1.2.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTK
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prometheus/client_golang v1.20.2 h1:5ctymQzZlyOON1666svgwn3s6IKWgfbjsejTMiXIyjg=
-github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
+github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
+github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G1dc=

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -38,7 +38,7 @@ type Run struct {
 	DryRun       bool
 	Hosts        []host.Host
 	Processor    processor.RepositoryTaskProcessor
-	Pushgateway  *push.Pusher
+	PushGateway  *push.Pusher
 	TaskRegistry *task.Registry
 }
 
@@ -163,10 +163,10 @@ func (r *Run) Run(repositoryNames, taskFiles []string) ([]RunResult, error) {
 }
 
 func (r *Run) pushMetrics() {
-	if r.Pushgateway != nil {
-		err := r.Pushgateway.Push()
+	if r.PushGateway != nil {
+		err := r.PushGateway.Push()
 		if err != nil {
-			log.Log().Warnw("Push to Prometheus Pushgateway failed", zap.Error(err))
+			log.Log().Warnw("Push to Prometheus PushGateway failed", zap.Error(err))
 		}
 	}
 }
@@ -193,7 +193,7 @@ func ExecuteRun(opts options.Opts, repositoryNames, taskFiles []string) ([]RunRe
 			DataDir: opts.DataDir(),
 			Git:     gitClient,
 		},
-		Pushgateway:  opts.Pushgateway,
+		PushGateway:  opts.PushGateway,
 		TaskRegistry: taskRegistry,
 	}
 	return e.Run(repositoryNames, taskFiles)

--- a/pkg/command/run_test.go
+++ b/pkg/command/run_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/h2non/gock"
+	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wndhydrnt/saturn-bot/pkg/action"
@@ -176,17 +178,25 @@ func TestExecuteRunner_Run(t *testing.T) {
 		Process(gomock.AssignableToTypeOf(ctx), false, repoWithPr, gomock.AssignableToTypeOf(anyTask), true, gomock.Any()).
 		Return(processor.ResultNoChanges, nil)
 
+	defer gock.Off()
+	gock.New("http://pgw.local").
+		Put("/metrics/job/saturn-bot").
+		Reply(200)
+	pushGateway := push.New("http://pgw.local", "saturn-bot")
+
 	runner := &command.Run{
 		Cache:        cache,
 		DryRun:       false,
 		Hosts:        []host.Host{hostm},
 		Processor:    procMock,
+		PushGateway:  pushGateway,
 		TaskRegistry: task.NewRegistry(runTestOpts),
 	}
 	_, err := runner.Run([]string{}, []string{taskFile})
 
 	require.NoError(t, err)
 	assert.NotEqual(t, cacheLastExecutionBefore, cache.GetLastExecutionAt(), "Updates the lat execution time in the cache")
+	require.True(t, gock.IsDone(), "All expected HTTP have occurred")
 }
 
 func TestExecuteRunner_Run_DryRun(t *testing.T) {

--- a/pkg/command/run_test.go
+++ b/pkg/command/run_test.go
@@ -196,7 +196,7 @@ func TestExecuteRunner_Run(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotEqual(t, cacheLastExecutionBefore, cache.GetLastExecutionAt(), "Updates the lat execution time in the cache")
-	require.True(t, gock.IsDone(), "All expected HTTP have occurred")
+	require.True(t, gock.IsDone(), "All HTTP requests sent")
 }
 
 func TestExecuteRunner_Run_DryRun(t *testing.T) {

--- a/pkg/config/config.schema.json
+++ b/pkg/config/config.schema.json
@@ -94,6 +94,10 @@
       "enum": ["debug", "error", "info", "warn"],
       "type": "string"
     },
+    "pushgatewayUrl": {
+      "description": "Address of a Prometheus Pushgateway to send metrics to.",
+      "type": "string"
+    },
     "pythonPath": {
       "default": "python",
       "description": "Path to the Python binary to execute plugins. If not set explicitly, then saturn-bot searches for the binary in $PATH.",

--- a/pkg/config/config.schema.json
+++ b/pkg/config/config.schema.json
@@ -94,7 +94,7 @@
       "enum": ["debug", "error", "info", "warn"],
       "type": "string"
     },
-    "pushgatewayUrl": {
+    "prometheusPushgatewayUrl": {
       "description": "Address of a Prometheus Pushgateway to send metrics to.",
       "type": "string"
     },

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -64,6 +64,9 @@ type Configuration struct {
 	// order to display the logs of a plugin.
 	PluginLogLevel ConfigurationPluginLogLevel `json:"pluginLogLevel,omitempty" yaml:"pluginLogLevel,omitempty" mapstructure:"pluginLogLevel,omitempty"`
 
+	// Address of a Prometheus Pushgateway to send metrics to.
+	PushgatewayUrl *string `json:"pushgatewayUrl,omitempty" yaml:"pushgatewayUrl,omitempty" mapstructure:"pushgatewayUrl,omitempty"`
+
 	// Path to the Python binary to execute plugins. If not set explicitly, then
 	// saturn-bot searches for the binary in $PATH.
 	PythonPath string `json:"pythonPath,omitempty" yaml:"pythonPath,omitempty" mapstructure:"pythonPath,omitempty"`

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -65,7 +65,7 @@ type Configuration struct {
 	PluginLogLevel ConfigurationPluginLogLevel `json:"pluginLogLevel,omitempty" yaml:"pluginLogLevel,omitempty" mapstructure:"pluginLogLevel,omitempty"`
 
 	// Address of a Prometheus Pushgateway to send metrics to.
-	PushgatewayUrl *string `json:"pushgatewayUrl,omitempty" yaml:"pushgatewayUrl,omitempty" mapstructure:"pushgatewayUrl,omitempty"`
+	PrometheusPushgatewayUrl *string `json:"prometheusPushgatewayUrl,omitempty" yaml:"prometheusPushgatewayUrl,omitempty" mapstructure:"prometheusPushgatewayUrl,omitempty"`
 
 	// Path to the Python binary to execute plugins. If not set explicitly, then
 	// saturn-bot searches for the binary in $PATH.

--- a/pkg/host/github.go
+++ b/pkg/host/github.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-github/v59/github"
 	"github.com/gregjones/httpcache"
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
+	"github.com/wndhydrnt/saturn-bot/pkg/metrics"
 )
 
 var (
@@ -495,14 +496,17 @@ type GitHubHost struct {
 }
 
 func NewGitHubHost(address, token string, cacheDisabled bool) (*GitHubHost, error) {
-	var httpClient *http.Client
-	if cacheDisabled {
-		httpClient = &http.Client{}
-	} else {
-		httpClient = httpcache.NewMemoryCacheTransport().Client()
+	httpClient := &http.Client{
+		Timeout:   2 * time.Second,
+		Transport: http.DefaultTransport,
+	}
+	metrics.InstrumentHttpClient(httpClient)
+	if !cacheDisabled {
+		transport := httpcache.NewMemoryCacheTransport()
+		transport.Transport = httpClient.Transport
+		httpClient.Transport = transport
 	}
 
-	httpClient.Timeout = 2 * time.Second
 	client := github.NewClient(httpClient)
 	client = client.WithAuthToken(token)
 	if address != "" {

--- a/pkg/host/github.go
+++ b/pkg/host/github.go
@@ -500,6 +500,10 @@ func NewGitHubHost(address, token string, cacheDisabled bool) (*GitHubHost, erro
 		Timeout:   2 * time.Second,
 		Transport: http.DefaultTransport,
 	}
+	// Set up metrics first, then add the caching layer.
+	// Makes the caching layer execute before the metrics.
+	// If it reads from cache then those calls aren't counted
+	// as requests.
 	metrics.InstrumentHttpClient(httpClient)
 	if !cacheDisabled {
 		transport := httpcache.NewMemoryCacheTransport()

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -16,7 +16,7 @@ var (
 	httpClientRequestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Help: "Total number of requests sent via HTTP clients.",
-			Name: "saturn_bot_http_client_requests_total",
+			Name: "http_client_requests_total",
 		},
 		[]string{"code", "method", hostLabel},
 	)

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	hostLabel = "host"
+)
+
+var (
+	httpClientRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Help: "Total number of requests sent via HTTP clients.",
+			Name: "saturn_bot_http_client_requests_total",
+		},
+		[]string{"code", "method", hostLabel},
+	)
+)
+
+type hostLabelCtxKey struct{}
+
+func newRoundTripper(next http.RoundTripper) promhttp.RoundTripperFunc {
+	return func(req *http.Request) (*http.Response, error) {
+		ctx := context.WithValue(req.Context(), hostLabelCtxKey{}, req.Host)
+		return next.RoundTrip(req.WithContext(ctx))
+	}
+}
+
+func InstrumentHttpClient(c *http.Client) {
+	opts := promhttp.WithLabelFromCtx(hostLabel,
+		func(ctx context.Context) string {
+			return ctx.Value(hostLabelCtxKey{}).(string)
+		},
+	)
+
+	roundTripper := newRoundTripper(
+		promhttp.InstrumentRoundTripperCounter(httpClientRequestsTotal, c.Transport, opts),
+	)
+	c.Transport = roundTripper
+}

--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -24,6 +24,9 @@ var (
 
 type hostLabelCtxKey struct{}
 
+// newRoundTripper adds the host of the request to the context of the request.
+// Prometheus instrumentation reads from the context to populate the label "host".
+// See promhttp.WithLabelFromCtx() and InstrumentHttpClient().
 func newRoundTripper(next http.RoundTripper) promhttp.RoundTripperFunc {
 	return func(req *http.Request) (*http.Response, error) {
 		ctx := context.WithValue(req.Context(), hostLabelCtxKey{}, req.Host)
@@ -32,6 +35,7 @@ func newRoundTripper(next http.RoundTripper) promhttp.RoundTripperFunc {
 }
 
 func InstrumentHttpClient(c *http.Client) {
+	// Read label "host" from context.
 	opts := promhttp.WithLabelFromCtx(hostLabel,
 		func(ctx context.Context) string {
 			return ctx.Value(hostLabelCtxKey{}).(string)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,7 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+func Register(reg prometheus.Registerer) {
+	reg.MustRegister(httpClientRequestsTotal, RunTaskSuccess, RunFinish, RunStart)
+}

--- a/pkg/metrics/run.go
+++ b/pkg/metrics/run.go
@@ -1,0 +1,21 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	RunTaskSuccess = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Help: "Status of the last run of a task. 1 indicates a successful run. 0 indicates a failed run.",
+			Name: "saturn_bot_run_task_success",
+		},
+		[]string{"task"},
+	)
+	RunFinish = prometheus.NewGauge(prometheus.GaugeOpts{
+		Help: "Last unix time when the most recent run finished.",
+		Name: "saturn_bot_run_finish_time_seconds",
+	})
+	RunStart = prometheus.NewGauge(prometheus.GaugeOpts{
+		Help: "Last unix time when the most recent run started.",
+		Name: "saturn_bot_run_start_time_seconds",
+	})
+)

--- a/pkg/metrics/run.go
+++ b/pkg/metrics/run.go
@@ -5,17 +5,17 @@ import "github.com/prometheus/client_golang/prometheus"
 var (
 	RunTaskSuccess = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Help: "Status of the last run of a task. 1 indicates a successful run. 0 indicates a failed run.",
-			Name: "saturn_bot_run_task_success",
+			Help: "Status of the last run of a task. 1 indicates success. 0 indicates failure.",
+			Name: "run_task_success",
 		},
 		[]string{"task"},
 	)
 	RunFinish = prometheus.NewGauge(prometheus.GaugeOpts{
-		Help: "Last unix time when the most recent run finished.",
-		Name: "saturn_bot_run_finish_time_seconds",
+		Help: "Last unix time when the run finished.",
+		Name: "run_finish_time_seconds",
 	})
 	RunStart = prometheus.NewGauge(prometheus.GaugeOpts{
-		Help: "Last unix time when the most recent run started.",
-		Name: "saturn_bot_run_start_time_seconds",
+		Help: "Last unix time when the run started.",
+		Name: "run_start_time_seconds",
 	})
 )

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -7,12 +7,15 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/wndhydrnt/saturn-bot/pkg/action"
 	"github.com/wndhydrnt/saturn-bot/pkg/config"
 	"github.com/wndhydrnt/saturn-bot/pkg/filter"
 	"github.com/wndhydrnt/saturn-bot/pkg/host"
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	sLog "github.com/wndhydrnt/saturn-bot/pkg/log"
+	"github.com/wndhydrnt/saturn-bot/pkg/metrics"
 )
 
 var (
@@ -51,6 +54,7 @@ type Opts struct {
 	Hosts           []host.Host
 	IsCi            bool
 	SkipPlugins     bool
+	Pushgateway     *push.Pusher
 
 	dataDir            string
 	workerLoopInterval time.Duration
@@ -155,7 +159,14 @@ func Initialize(opts *Opts) error {
 	if err != nil {
 		return fmt.Errorf("setting workerLoopInterval '%s' is not a Go duration: %w", opts.Config.WorkerLoopInterval, err)
 	}
-
 	opts.workerLoopInterval = loop
+
+	if opts.Config.PushgatewayUrl != nil {
+		reg := prometheus.NewRegistry()
+		metrics.Register(reg)
+		opts.Pushgateway = push.New(*opts.Config.PushgatewayUrl, "saturn_bot").
+			Collector(reg)
+	}
+
 	return nil
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -161,10 +161,10 @@ func Initialize(opts *Opts) error {
 	}
 	opts.workerLoopInterval = loop
 
-	if opts.Config.PushgatewayUrl != nil {
+	if opts.Config.PrometheusPushgatewayUrl != nil {
 		reg := prometheus.NewRegistry()
 		metrics.Register(reg)
-		opts.Pushgateway = push.New(*opts.Config.PushgatewayUrl, "saturn_bot").
+		opts.Pushgateway = push.New(*opts.Config.PrometheusPushgatewayUrl, "saturn_bot").
 			Collector(reg)
 	}
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -54,7 +54,7 @@ type Opts struct {
 	Hosts           []host.Host
 	IsCi            bool
 	SkipPlugins     bool
-	Pushgateway     *push.Pusher
+	PushGateway     *push.Pusher
 
 	dataDir            string
 	workerLoopInterval time.Duration
@@ -164,7 +164,7 @@ func Initialize(opts *Opts) error {
 	if opts.Config.PrometheusPushgatewayUrl != nil {
 		reg := prometheus.NewRegistry()
 		metrics.Register(reg)
-		opts.Pushgateway = push.New(*opts.Config.PrometheusPushgatewayUrl, "saturn_bot").
+		opts.PushGateway = push.New(*opts.Config.PrometheusPushgatewayUrl, "saturn-bot").
 			Collector(reg)
 	}
 

--- a/pkg/worker/metrics.go
+++ b/pkg/worker/metrics.go
@@ -4,6 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	promversioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	promversion "github.com/prometheus/common/version"
+	"github.com/wndhydrnt/saturn-bot/pkg/metrics"
 	"github.com/wndhydrnt/saturn-bot/pkg/version"
 )
 
@@ -52,6 +53,7 @@ func initMetrics() {
 		metricRunsMax,
 		metricServerRequestsFailed,
 	)
+	metrics.Register(prometheus.DefaultRegisterer)
 	metricRunsFailed.Add(0)
 	metricRuns.Set(0)
 	metricRunsMax.Set(0)


### PR DESCRIPTION
- URL to Pushgateway configured via configuration file.
- Job label is `saturn-bot`.
- Define and document metrics.
- Instrument HTTP clients to expose how many requests are sent during a run.