### PR TITLE
feat(git): Add metrics to track number and duration of git commands

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -10,6 +10,20 @@ The `job` label added to all metrics is `saturn-bot`.
 
 The following metrics exist:
 
+## `git_commands_duration_seconds_count`
+
+Total number of commands executed by git.
+
+Use this metric to understand how much load saturn-bot puts
+on a repository host by, for example, cloning repositories or pushing commits.
+
+## `git_commands_duration_seconds_sum`
+
+Total duration it took for git to execute commands.
+
+Use together with `git_commands_duration_seconds_count` to calculate the average duration
+and understand the repository host is slow.
+
 ## `http_client_requests_total`
 
 Total number of requests sent via HTTP clients.

--- a/pkg/metrics/git.go
+++ b/pkg/metrics/git.go
@@ -1,0 +1,14 @@
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	GitCommandsDurationSecondsCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Help: "Total number of commands executed by git.",
+		Name: "git_commands_duration_seconds_count",
+	}, []string{"command"})
+	GitCommandsDurationSecondsSum = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Help: "Total duration it took for git to execute commands.",
+		Name: "git_commands_duration_seconds_sum",
+	}, []string{"command"})
+)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,5 +3,12 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 func Register(reg prometheus.Registerer) {
-	reg.MustRegister(httpClientRequestsTotal, RunTaskSuccess, RunFinish, RunStart)
+	reg.MustRegister(
+		GitCommandsDurationSecondsCount,
+		GitCommandsDurationSecondsSum,
+		httpClientRequestsTotal,
+		RunTaskSuccess,
+		RunFinish,
+		RunStart,
+	)
 }


### PR DESCRIPTION
- Measure number of commands executed.
- Measure time it took to execute commands.
- Break by name of command.
- Document mentrics.