### PR TITLE
fix(host): Do not time out if rate-limiting of GitLab API is active

### DIFF
--- a/pkg/host/gitlab.go
+++ b/pkg/host/gitlab.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/metrics"
 	"github.com/xanzy/go-gitlab"
@@ -536,10 +537,7 @@ type GitLabHost struct {
 }
 
 func NewGitLabHost(addr, token string) (*GitLabHost, error) {
-	httpClient := &http.Client{
-		Timeout:   2 * time.Second,
-		Transport: http.DefaultTransport,
-	}
+	httpClient := cleanhttp.DefaultPooledClient()
 	metrics.InstrumentHttpClient(httpClient)
 
 	client, err := gitlab.NewClient(


### PR DESCRIPTION
Do not set a timeout on `http.Client`.
It clashes with the automatic backoff algorithm in the library.
The library waits until the backoff period is over, which is almost always longer than the timeout.

Create the client in the same way the code in `github.com/xanzy/go-gitlab` does it.