### PR TITLE
fix(host): Too eager to delete GitHub branch

### DIFF
--- a/pkg/host/github.go
+++ b/pkg/host/github.go
@@ -311,7 +311,9 @@ func (g *GitHubRepository) MergePullRequest(deleteBranch bool, pr interface{}) e
 		return fmt.Errorf("merge github pull request %d: %w", gpr.GetNumber(), err)
 	}
 
-	if deleteBranch {
+	// Don't delete if DeleteBranchOnMerge == true.
+	// GitHub deletes the branch on its own.
+	if deleteBranch && !g.repo.GetDeleteBranchOnMerge() {
 		return g.DeleteBranch(pr)
 	}
 


### PR DESCRIPTION
GitHub deletes a branch automatically if configured in the settings of a repository.
No need to try and delete the branch too.