### PR TITLE
feat(server): Add endpoint to process webhooks sent by GitLab

### DIFF
--- a/pkg/config/config.schema.json
+++ b/pkg/config/config.schema.json
@@ -138,6 +138,11 @@
       "description": "Secret to authenticate webhook requests sent by GitHub.",
       "type": "string"
     },
+    "serverGitlabWebhookSecret": {
+      "default": "",
+      "description": "Secret to authenticate webhook requests sent by GitLab. See https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#create-a-webhook for how to set up the token.",
+      "type": "string"
+    },
     "workerLoopInterval": {
       "default": "10s",
       "description": "Interval at which a worker queries the server for new tasks to run.",

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -95,6 +95,11 @@ type Configuration struct {
 	// Secret to authenticate webhook requests sent by GitHub.
 	ServerGithubWebhookSecret string `json:"serverGithubWebhookSecret,omitempty" yaml:"serverGithubWebhookSecret,omitempty" mapstructure:"serverGithubWebhookSecret,omitempty"`
 
+	// Secret to authenticate webhook requests sent by GitLab. See
+	// https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#create-a-webhook
+	// for how to set up the token.
+	ServerGitlabWebhookSecret string `json:"serverGitlabWebhookSecret,omitempty" yaml:"serverGitlabWebhookSecret,omitempty" mapstructure:"serverGitlabWebhookSecret,omitempty"`
+
 	// Interval at which a worker queries the server for new tasks to run.
 	WorkerLoopInterval string `json:"workerLoopInterval,omitempty" yaml:"workerLoopInterval,omitempty" mapstructure:"workerLoopInterval,omitempty"`
 
@@ -446,6 +451,9 @@ func (j *Configuration) UnmarshalJSON(b []byte) error {
 	if v, ok := raw["serverGithubWebhookSecret"]; !ok || v == nil {
 		plain.ServerGithubWebhookSecret = ""
 	}
+	if v, ok := raw["serverGitlabWebhookSecret"]; !ok || v == nil {
+		plain.ServerGitlabWebhookSecret = ""
+	}
 	if v, ok := raw["workerLoopInterval"]; !ok || v == nil {
 		plain.WorkerLoopInterval = "10s"
 	}
@@ -535,6 +543,9 @@ func (j *Configuration) UnmarshalYAML(value *yaml.Node) error {
 	}
 	if v, ok := raw["serverGithubWebhookSecret"]; !ok || v == nil {
 		plain.ServerGithubWebhookSecret = ""
+	}
+	if v, ok := raw["serverGitlabWebhookSecret"]; !ok || v == nil {
+		plain.ServerGitlabWebhookSecret = ""
 	}
 	if v, ok := raw["workerLoopInterval"]; !ok || v == nil {
 		plain.WorkerLoopInterval = "10s"

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
 	"gopkg.in/yaml.v3"
 )
@@ -67,4 +69,13 @@ func RegisterHealthRoute(router chi.Router) {
 		const up = "UP"
 		_, _ = fmt.Fprint(w, up)
 	})
+}
+
+func DiscardRequest(r *http.Request) {
+	if _, err := io.Copy(io.Discard, r.Body); err != nil {
+		log.Log().Debug("Failed to discard request body")
+	}
+	if err := r.Body.Close(); err != nil {
+		log.Log().Debug("Failed to close request body")
+	}
 }

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -72,9 +71,6 @@ func RegisterHealthRoute(router chi.Router) {
 }
 
 func DiscardRequest(r *http.Request) {
-	if _, err := io.Copy(io.Discard, r.Body); err != nil {
-		log.Log().Debug("Failed to discard request body")
-	}
 	if err := r.Body.Close(); err != nil {
 		log.Log().Debug("Failed to close request body")
 	}

--- a/pkg/server/api/github.go
+++ b/pkg/server/api/github.go
@@ -40,11 +40,10 @@ func (h *GithubWebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Requ
 
 	// Note: GitHub expects a response within 10 seconds.
 	log.Log().Debugf("Enqueuing GitHub webhook %s", whID)
-	err = h.WebhookService.Enqueue(&service.EnqueueInput{
+	err = h.WebhookService.EnqueueGithub(&service.WebhookEnqueueInput{
 		Event:   whType,
 		ID:      whID,
 		Payload: content,
-		Type:    service.GithubWebhookType,
 	})
 	if err != nil {
 		log.Log().Errorw("Failed to enqueue GitHub webhook", zap.Error(err))

--- a/pkg/server/api/github.go
+++ b/pkg/server/api/github.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// GithubWebhookHandler handles webhooks received by GitLab.
+// GithubWebhookHandler handles webhooks sent by GitHub.
 type GithubWebhookHandler struct {
 	SecretKey      []byte
 	WebhookService *service.WebhookService

--- a/pkg/server/api/github.go
+++ b/pkg/server/api/github.go
@@ -20,6 +20,7 @@ type GithubWebhookHandler struct {
 // HandleWebhook parses and validates a webhook sent by GitHub.
 // If the webhook is valid, it sends the webhook on for processing.
 func (h *GithubWebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
+	defer DiscardRequest(r)
 	payload, err := github.ValidatePayload(r, h.SecretKey)
 	if err != nil {
 		log.Log().Errorw("Failed to validate GitHub webhook", zap.Error(err))

--- a/pkg/server/api/gitlab.go
+++ b/pkg/server/api/gitlab.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/service"
 	"github.com/xanzy/go-gitlab"
@@ -62,4 +63,10 @@ func (gh *GitlabWebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Req
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+// RegisterGitlabWebhookHandler registers the handler with a [github.com/go-chi/chi/v5.Router].
+func RegisterGitlabWebhookHandler(router chi.Router, token string, ws *service.WebhookService) {
+	h := &GitlabWebhookHandler{SecretToken: token, WebhookService: ws}
+	router.Post("/webhooks/gitlab", h.HandleWebhook)
 }

--- a/pkg/server/api/gitlab.go
+++ b/pkg/server/api/gitlab.go
@@ -51,6 +51,7 @@ func (gh *GitlabWebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Use map[string]any because gojq expects it.
 	var event map[string]any
 	err = json.Unmarshal(payload, &event)
 	if err != nil {

--- a/pkg/server/api/gitlab.go
+++ b/pkg/server/api/gitlab.go
@@ -17,11 +17,17 @@ const (
 	gitlabWebhookTokenHeader   = "X-Gitlab-Token"
 )
 
+// GitlabWebhookHandler handles webhooks sent by GitLab.
 type GitlabWebhookHandler struct {
 	SecretToken    string
 	WebhookService *service.WebhookService
 }
 
+// HandleWebhook parses and validates a webhook sent by GitLab.
+// If the webhook is valid, it sends the webhook on for processing.
+// A webhook is considered valid if:
+// * The secret token from the request matches the configured secret token.
+// * The HTTP method is POST.
 func (gh *GitlabWebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 	defer DiscardRequest(r)
 	eventToken := r.Header.Get(gitlabWebhookTokenHeader)

--- a/pkg/server/api/gitlab.go
+++ b/pkg/server/api/gitlab.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 
@@ -44,14 +45,15 @@ func (gh *GitlabWebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	event, err := gitlab.ParseWebhook(eventType, payload)
+	var event map[string]any
+	err = json.Unmarshal(payload, &event)
 	if err != nil {
 		log.Log().Warn("Failed to parse GitLab webhook")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	err = gh.WebhookService.EnqueueGithub(&service.WebhookEnqueueInput{
+	err = gh.WebhookService.EnqueueGitlab(&service.WebhookEnqueueInput{
 		Event:   string(eventType),
 		ID:      r.Header.Get(gitlabWebhookEventIDHeader),
 		Payload: event,

--- a/pkg/server/api/gitlab.go
+++ b/pkg/server/api/gitlab.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	gitlabWebhookEventIDHeader = "X-Gitlab-Event-UUID"
-	gitlabWebhookTokenHeader   = "X-Gitlab-Token"
+	gitlabWebhookTokenHeader   = "X-Gitlab-Token" // #nosec G101 -- This is not a secret
 )
 
 // GitlabWebhookHandler handles webhooks sent by GitLab.

--- a/pkg/server/api/gitlab.go
+++ b/pkg/server/api/gitlab.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
+	"github.com/wndhydrnt/saturn-bot/pkg/server/service"
+	"github.com/xanzy/go-gitlab"
+	"go.uber.org/zap"
+)
+
+const (
+	gitlabWebhookEventIDHeader = "X-Gitlab-Event-UUID"
+	gitlabWebhookTokenHeader   = "X-Gitlab-Token"
+)
+
+type GitlabWebhookHandler struct {
+	SecretToken    string
+	WebhookService *service.WebhookService
+}
+
+func (gh *GitlabWebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
+	defer DiscardRequest(r)
+	eventToken := r.Header.Get(gitlabWebhookTokenHeader)
+	if eventToken != gh.SecretToken {
+		log.Log().Debug("GitLab webhook received request with wrong token")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		log.Log().Debug("GitLab webhook called with wrong HTTP method")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	eventType := gitlab.HookEventType(r)
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Log().Warn("Failed to read payload of GitLab webhook")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	event, err := gitlab.ParseWebhook(eventType, payload)
+	if err != nil {
+		log.Log().Warn("Failed to parse GitLab webhook")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	err = gh.WebhookService.EnqueueGithub(&service.WebhookEnqueueInput{
+		Event:   string(eventType),
+		ID:      r.Header.Get(gitlabWebhookEventIDHeader),
+		Payload: event,
+	})
+	if err != nil {
+		log.Log().Errorw("Failed to enqueue webhook", zap.Error(err))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/server/api/task.go
+++ b/pkg/server/api/task.go
@@ -20,8 +20,8 @@ func (ts *TaskHandler) GetTaskV1(_ context.Context, taskName string) (openapi.Im
 	}
 
 	body := openapi.GetTaskV1Response{
-		Name:    t.Task.Name,
-		Hash:    t.Sha256,
+		Name:    t.Name,
+		Hash:    t.Checksum(),
 		Content: content,
 	}
 	return openapi.Response(http.StatusOK, body), nil

--- a/pkg/server/api/work.go
+++ b/pkg/server/api/work.go
@@ -32,7 +32,7 @@ func (wh *WorkHandler) GetWorkV1(_ context.Context) (openapi.ImplResponse, error
 		Repositories: run.RepositoryNames,
 		RunID:        int32(run.ID), // #nosec G115 -- no info by gosec on how to fix this
 		Tasks: []openapi.GetWorkV1Task{
-			{Hash: task.Sha256, Name: task.Task.Name},
+			{Hash: task.Checksum(), Name: task.Task.Name},
 		},
 	}
 

--- a/pkg/server/integration/gitlab_test.go
+++ b/pkg/server/integration/gitlab_test.go
@@ -1,0 +1,217 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v59/github"
+	"github.com/wndhydrnt/saturn-bot/pkg/ptr"
+	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
+	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestServer_WebhookGitlab(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: `Given a task that triggers on GitLab webhook event "push"
+							When it receives a GitLab webhook
+							Then it creates a new work item for the task`,
+			tasks: []schema.Task{
+				{
+					Name: "unittest",
+					Trigger: &schema.TaskTrigger{
+						Webhook: &schema.TaskTriggerWebhook{
+							Gitlab: []schema.GitlabTrigger{
+								{Event: ptr.To("Push Hook"), Filters: []string{`.repository.path_with_namespace == "unit/test"`}},
+							},
+						},
+					},
+				},
+			},
+			apiCalls: []apiCall{
+				// Drain the run queue.
+				{
+					method:     "GET",
+					path:       "/api/v1/worker/work",
+					statusCode: http.StatusOK,
+					responseBody: openapi.GetWorkV1Response{
+						RunID: 1,
+						Tasks: []openapi.GetWorkV1Task{
+							{Hash: "35e6e13d4ec91723e96cf0e93998043d042d98a637fe56f09bee1cd8558ea950", Name: "unittest"},
+						},
+					},
+				},
+				// And report the result of the run.
+				{
+					method: "POST",
+					path:   "/api/v1/worker/work",
+					requestBody: openapi.ReportWorkV1Request{
+						RunID:       1,
+						TaskResults: []openapi.ReportWorkV1TaskResult{},
+					},
+					statusCode: http.StatusCreated,
+					responseBody: openapi.ReportWorkV1Response{
+						Result: "ok",
+					},
+				},
+				// Send the webhook request
+				{
+					method: "POST",
+					path:   "/webhooks/gitlab",
+					requestHeaders: map[string]string{
+						"X-Gitlab-Event": "Push Hook",
+						"X-Gitlab-Token": "secret",
+					},
+					requestBody: gitlab.PushEvent{
+						Repository: &gitlab.Repository{PathWithNamespace: "unit/test"},
+					},
+					statusCode: http.StatusOK,
+				},
+				// Check for the newly scheduled run.
+				{
+					sleep:      5 * time.Millisecond, // Need to sleep because write of webhook happens in goroutine
+					method:     "GET",
+					path:       "/api/v1/worker/work",
+					statusCode: http.StatusOK,
+					responseBody: openapi.GetWorkV1Response{
+						RunID: 2,
+						Tasks: []openapi.GetWorkV1Task{
+							{Hash: "35e6e13d4ec91723e96cf0e93998043d042d98a637fe56f09bee1cd8558ea950", Name: "unittest"},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: `Given a task that triggers on GitLab webhook event "push" and specifies a filter
+							When it receives a GitLab webhook that does not match the filter
+							Then it does not create a new work item for the task`,
+			tasks: []schema.Task{
+				{
+					Name: "unittest",
+					Trigger: &schema.TaskTrigger{
+						Webhook: &schema.TaskTriggerWebhook{
+							Gitlab: []schema.GitlabTrigger{
+								{Event: ptr.To("Push Hook"), Filters: []string{`.repository.path_with_namespace == "unit/test"`}},
+							},
+						},
+					},
+				},
+			},
+			apiCalls: []apiCall{
+				// Drain the run queue.
+				{
+					method:     "GET",
+					path:       "/api/v1/worker/work",
+					statusCode: http.StatusOK,
+					responseBody: openapi.GetWorkV1Response{
+						RunID: 1,
+						Tasks: []openapi.GetWorkV1Task{
+							{Hash: "35e6e13d4ec91723e96cf0e93998043d042d98a637fe56f09bee1cd8558ea950", Name: "unittest"},
+						},
+					},
+				},
+				// And report the result of the run.
+				{
+					method: "POST",
+					path:   "/api/v1/worker/work",
+					requestBody: openapi.ReportWorkV1Request{
+						RunID:       1,
+						TaskResults: []openapi.ReportWorkV1TaskResult{},
+					},
+					statusCode: http.StatusCreated,
+					responseBody: openapi.ReportWorkV1Response{
+						Result: "ok",
+					},
+				},
+				// Send the webhook request
+				{
+					method: "POST",
+					path:   "/webhooks/gitlab",
+					requestHeaders: map[string]string{
+						"X-Gitlab-Event": "Push Hook",
+						"X-Gitlab-Token": "secret",
+					},
+					requestBody: gitlab.PushEvent{
+						Repository: &gitlab.Repository{PathWithNamespace: "unit/other"},
+					},
+					statusCode: http.StatusOK,
+				},
+				// Check that no new run has been scheduled.
+				{
+					sleep:        5 * time.Millisecond, // Need to sleep because write of webhook happens in goroutine
+					method:       "GET",
+					path:         "/api/v1/worker/work",
+					statusCode:   http.StatusOK,
+					responseBody: openapi.GetWorkV1Response{},
+				},
+			},
+		},
+
+		{
+			name: `Given a task that does not trigger on a GitLab webhook event
+							When it receives a GitLab webhook
+							Then it does not create a new work item for the task`,
+			tasks: []schema.Task{
+				{
+					Name: "unittest",
+				},
+			},
+			apiCalls: []apiCall{
+				// Drain the run queue.
+				{
+					method:     "GET",
+					path:       "/api/v1/worker/work",
+					statusCode: http.StatusOK,
+					responseBody: openapi.GetWorkV1Response{
+						RunID: 1,
+						Tasks: []openapi.GetWorkV1Task{
+							{Hash: "e42a6e186f31b860f22f07ed468b99c6dc75318542fc9ac8383358fae1b5ab8b", Name: "unittest"},
+						},
+					},
+				},
+				// And report the result of the run.
+				{
+					method: "POST",
+					path:   "/api/v1/worker/work",
+					requestBody: openapi.ReportWorkV1Request{
+						RunID:       1,
+						TaskResults: []openapi.ReportWorkV1TaskResult{},
+					},
+					statusCode: http.StatusCreated,
+					responseBody: openapi.ReportWorkV1Response{
+						Result: "ok",
+					},
+				},
+				// Send the webhook request
+				{
+					method: "POST",
+					path:   "/webhooks/gitlab",
+					requestHeaders: map[string]string{
+						"X-Gitlab-Event": "Push Hook",
+						"X-Gitlab-Token": "secret",
+					},
+					requestBody: github.PushEvent{},
+					statusCode:  http.StatusOK,
+				},
+				// Check that no new run has been scheduled.
+				{
+					sleep:        5 * time.Millisecond, // Need to sleep because write of webhook happens in goroutine
+					method:       "GET",
+					path:         "/api/v1/worker/work",
+					statusCode:   http.StatusOK,
+					responseBody: openapi.GetWorkV1Response{},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			executeTestCase(t, tc)
+		})
+	}
+}

--- a/pkg/server/integration/integration_test.go
+++ b/pkg/server/integration/integration_test.go
@@ -24,6 +24,7 @@ var (
 	defaultServerConfig = config.Configuration{
 		GithubToken:               ptr.To("unittest"),
 		ServerGithubWebhookSecret: "secret",
+		ServerGitlabWebhookSecret: "secret",
 	}
 	defaultTask              = schema.Task{Name: "unittest"}
 	defaultTaskContentBase64 = "bmFtZTogdW5pdHRlc3QK"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -71,6 +71,7 @@ func (s *Server) Start(opts options.Opts, taskPaths []string) error {
 		return fmt.Errorf("create webhook service: %w", err)
 	}
 	api.RegisterGithubWebhookHandler(router, []byte(opts.Config.ServerGithubWebhookSecret), webhookService)
+	api.RegisterGitlabWebhookHandler(router, opts.Config.ServerGitlabWebhookSecret, webhookService)
 	err = api.RegisterOpenAPIDefinitionRoute(opts.Config.ServerBaseUrl, router)
 	if err != nil {
 		return fmt.Errorf("failed to register OpenAPI definition route: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,8 +23,6 @@ import (
 	"github.com/wndhydrnt/saturn-bot/pkg/server/metrics"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/service"
 	"github.com/wndhydrnt/saturn-bot/pkg/task"
-
-	// "github.com/wndhydrnt/saturn-bot/pkg/server/task"
 	"github.com/wndhydrnt/saturn-bot/pkg/version"
 	"go.uber.org/zap"
 )

--- a/pkg/server/service/taskservice.go
+++ b/pkg/server/service/taskservice.go
@@ -9,44 +9,44 @@ import (
 
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/db"
-	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
+	"github.com/wndhydrnt/saturn-bot/pkg/task"
 	"gorm.io/gorm"
 )
 
 type TaskService struct {
-	db    *gorm.DB
-	tasks []schema.ReadResult
+	db           *gorm.DB
+	taskRegistry *task.Registry
 }
 
-func NewTaskService(db *gorm.DB, tasks []schema.ReadResult) *TaskService {
-	return &TaskService{db: db, tasks: tasks}
+func NewTaskService(db *gorm.DB, taskRegistry *task.Registry) *TaskService {
+	return &TaskService{db: db, taskRegistry: taskRegistry}
 }
 
 func (ts *TaskService) SyncDbTasks() error {
-	for _, t := range ts.tasks {
+	for _, t := range ts.taskRegistry.GetTasks() {
 		var taskDB db.Task
-		tx := ts.db.Where("name = ?", t.Task.Name).First(&taskDB)
+		tx := ts.db.Where("name = ?", t.Name).First(&taskDB)
 		if tx.Error != nil {
 			if !errors.Is(tx.Error, gorm.ErrRecordNotFound) {
 				return tx.Error
 			}
 
-			log.Log().Debugf("Creating task %s in DB", t.Task.Name)
-			taskDB.Hash = t.Sha256
-			taskDB.Name = t.Task.Name
+			log.Log().Debugf("Creating task %s in DB", t.Name)
+			taskDB.Hash = t.Checksum()
+			taskDB.Name = t.Name
 			err := ts.db.Transaction(func(tx *gorm.DB) error {
 				if err := ts.db.Save(&taskDB).Error; err != nil {
-					return fmt.Errorf("create task '%s' in db: %w", t.Task.Name, err)
+					return fmt.Errorf("create task '%s' in db: %w", t.Name, err)
 				}
 
 				run := db.Run{
 					Reason:        0,
 					ScheduleAfter: time.Now(),
 					Status:        db.RunStatusPending,
-					TaskName:      t.Task.Name,
+					TaskName:      t.Name,
 				}
 				if err := ts.db.Save(&run).Error; err != nil {
-					return fmt.Errorf("schedule run for new task '%s' in db: %w", t.Task.Name, err)
+					return fmt.Errorf("schedule run for new task '%s' in db: %w", t.Name, err)
 				}
 
 				return nil
@@ -55,21 +55,21 @@ func (ts *TaskService) SyncDbTasks() error {
 				return err
 			}
 		} else {
-			if taskDB.Hash != t.Sha256 {
-				taskDB.Hash = t.Sha256
+			if taskDB.Hash != t.Checksum() {
+				taskDB.Hash = t.Checksum()
 				log.Log().Debugf("Updating task %s in DB", taskDB.Name)
 				run := db.Run{
 					Reason:        0,
 					ScheduleAfter: time.Now(),
 					Status:        db.RunStatusPending,
-					TaskName:      t.Task.Name,
+					TaskName:      t.Name,
 				}
 				if err := ts.db.Save(&run).Error; err != nil {
-					return fmt.Errorf("schedule run for updated task '%s' in db: %w", t.Task.Name, err)
+					return fmt.Errorf("schedule run for updated task '%s' in db: %w", t.Name, err)
 				}
 
 				if err := ts.db.Save(&taskDB).Error; err != nil {
-					return fmt.Errorf("update task '%s' in db: %w", t.Task.Name, err)
+					return fmt.Errorf("update task '%s' in db: %w", t.Name, err)
 				}
 			}
 		}
@@ -78,23 +78,23 @@ func (ts *TaskService) SyncDbTasks() error {
 	return nil
 }
 
-func (ts *TaskService) GetTask(taskName string) (*schema.ReadResult, string) {
-	for _, entry := range ts.tasks {
-		if entry.Task.Name == taskName {
-			content, err := encodeBase64(entry.Path)
+func (ts *TaskService) GetTask(taskName string) (*task.Task, string) {
+	for _, entry := range ts.taskRegistry.GetTasks() {
+		if entry.Name == taskName {
+			content, err := encodeBase64(entry.Path())
 			if err != nil {
 				return nil, ""
 			}
 
-			return &entry, content
+			return entry, content
 		}
 	}
 
 	return nil, ""
 }
 
-func (ts *TaskService) ListTasks() []schema.ReadResult {
-	return ts.tasks
+func (ts *TaskService) ListTasks() []*task.Task {
+	return ts.taskRegistry.GetTasks()
 }
 
 func encodeBase64(path string) (string, error) {

--- a/pkg/server/service/webhook.go
+++ b/pkg/server/service/webhook.go
@@ -60,8 +60,6 @@ func (s *WebhookService) enqueue(in *WebhookEnqueueInput, triggerCache map[strin
 				break
 			}
 		}
-
-		log.Log().Debugf("Task %s does not match webhook %s", taskName, in.ID)
 	}
 
 	return errors.Join(errs...)
@@ -69,6 +67,7 @@ func (s *WebhookService) enqueue(in *WebhookEnqueueInput, triggerCache map[strin
 
 func (s *WebhookService) populateCaches() error {
 	s.githubTriggerCache = map[string][]cacheEntry{}
+	s.gitlabTriggerCache = map[string][]cacheEntry{}
 	for _, t := range s.taskRegistry.GetTasks() {
 		if hasGithubWebhookTrigger(t.Trigger) {
 			err := s.populateGithubCache(t)
@@ -114,7 +113,7 @@ func (s *WebhookService) populateGitlabCache(t *task.Task) error {
 		cacheEntries[idxHook] = cacheEntry{event: ptr.From(hook.Event), filters: filters}
 	}
 
-	s.githubTriggerCache[t.Name] = cacheEntries
+	s.gitlabTriggerCache[t.Name] = cacheEntries
 	return nil
 }
 
@@ -162,7 +161,7 @@ func match(event string, trigger cacheEntry, payload any) bool {
 		}
 
 		if valueRaw == nil {
-			// Query matched nothing.
+			// Query matches nothing.
 			return false
 		}
 
@@ -173,7 +172,7 @@ func match(event string, trigger cacheEntry, payload any) bool {
 		}
 
 		if !value {
-			// Query evaluated to false.
+			// Query evaluates to false.
 			return false
 		}
 	}

--- a/pkg/server/service/webhook.go
+++ b/pkg/server/service/webhook.go
@@ -51,13 +51,13 @@ type WebhookEnqueueInput struct {
 	Payload any
 }
 
-// EnqueueGithub enqueues new runs when a webhook by GitHub is received by the server.
+// EnqueueGithub enqueues new runs when a webhook from GitHub is received by the server.
 // It visits every task that configures triggers for GitHub webhooks.
 func (s *WebhookService) EnqueueGithub(in *WebhookEnqueueInput) error {
 	return s.enqueue(in, s.githubTriggerCache, webhookTypeGithub)
 }
 
-// EnqueueGitlab enqueues new runs when a webhook by GitLab is received by the server.
+// EnqueueGitlab enqueues new runs when a webhook from GitLab is received by the server.
 // It visits every task that configures triggers for GitLab webhooks.
 func (s *WebhookService) EnqueueGitlab(in *WebhookEnqueueInput) error {
 	return s.enqueue(in, s.gitlabTriggerCache, webhookTypeGitlab)
@@ -197,7 +197,7 @@ func match(event string, trigger cacheEntry, payload any) bool {
 }
 
 func parseHookFilters(filters []string) ([]*gojq.Code, error) {
-	var codes []*gojq.Code
+	codes := make([]*gojq.Code, len(filters))
 	for idxFilter, filter := range filters {
 		query, err := gojq.Parse(filter)
 		if err != nil {
@@ -208,7 +208,8 @@ func parseHookFilters(filters []string) ([]*gojq.Code, error) {
 		if err != nil {
 			return nil, fmt.Errorf("compile jq expression of item %d: %w", idxFilter, err)
 		}
-		codes = append(codes, compiledQuery)
+
+		codes[idxFilter] = compiledQuery
 	}
 
 	return codes, nil

--- a/pkg/server/service/webhook.go
+++ b/pkg/server/service/webhook.go
@@ -9,23 +9,24 @@ import (
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/ptr"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/db"
+	"github.com/wndhydrnt/saturn-bot/pkg/task"
 	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
 )
 
-type WebhookType uint
-
-const (
-	GithubWebhookType WebhookType = iota
-)
-
-type WebhookService struct {
-	githubFilterCache map[string]map[int][]*gojq.Code
-	tasks             []schema.ReadResult
-	workerService     *WorkerService
+type cacheEntry struct {
+	event   string
+	filters []*gojq.Code
 }
 
-func NewWebhookService(tasks []schema.ReadResult, workerService *WorkerService) (*WebhookService, error) {
-	s := &WebhookService{tasks: tasks, workerService: workerService}
+type WebhookService struct {
+	githubTriggerCache map[string][]cacheEntry
+	gitlabTriggerCache map[string][]cacheEntry
+	taskRegistry       *task.Registry
+	workerService      *WorkerService
+}
+
+func NewWebhookService(taskRegistry *task.Registry, workerService *WorkerService) (*WebhookService, error) {
+	s := &WebhookService{taskRegistry: taskRegistry, workerService: workerService}
 	err := s.populateCaches()
 	if err != nil {
 		return nil, fmt.Errorf("populate filter caches: %w", err)
@@ -34,107 +35,87 @@ func NewWebhookService(tasks []schema.ReadResult, workerService *WorkerService) 
 	return s, nil
 }
 
-type EnqueueInput struct {
+type WebhookEnqueueInput struct {
 	Event   string
 	ID      string
 	Payload any
-	Type    WebhookType
 }
 
-func (s *WebhookService) Enqueue(in *EnqueueInput) error {
-	if s.githubFilterCache == nil {
-		err := s.populateCaches()
-		if err != nil {
-			return err
-		}
-	}
+func (s *WebhookService) EnqueueGithub(in *WebhookEnqueueInput) error {
+	return s.enqueue(in, s.githubTriggerCache)
+}
 
+func (s *WebhookService) EnqueueGitlab(in *WebhookEnqueueInput) error {
+	return s.enqueue(in, s.gitlabTriggerCache)
+}
+
+func (s *WebhookService) enqueue(in *WebhookEnqueueInput, triggerCache map[string][]cacheEntry) error {
 	var errs []error
-	for _, task := range s.tasks {
-		if !hasGithubWebhookTrigger(task.Task.Trigger) {
-			log.Log().Debugf("Task %s does not define GitHub webhooks", task.Task.Name)
-			continue
-		}
-
-		for idx, trigger := range task.Task.Trigger.Webhook.Github {
-			if s.match(in.Event, idx, task.Task.Name, trigger, in.Payload) {
-				log.Log().Debugf("Task %s matches GitHub webhook %s", task.Task.Name, in.ID)
-				_, err := s.workerService.ScheduleRun(db.RunReasonWebhook, nil, time.Now(), task.Task.Name, nil)
+	for taskName, triggers := range triggerCache {
+		for _, trigger := range triggers {
+			if match(in.Event, trigger, in.Payload) {
+				log.Log().Debugf("Task %s matches webhook %s", taskName, in.ID)
+				_, err := s.workerService.ScheduleRun(db.RunReasonWebhook, nil, time.Now(), taskName, nil)
 				errs = append(errs, err)
-			} else {
-				log.Log().Debugf("Task %s does not match GitHub webhook %s", task.Task.Name, in.ID)
+				break
 			}
 		}
+
+		log.Log().Debugf("Task %s does not match webhook %s", taskName, in.ID)
 	}
 
 	return errors.Join(errs...)
 }
 
 func (s *WebhookService) populateCaches() error {
-	m := map[string]map[int][]*gojq.Code{}
-	for _, t := range s.tasks {
-		if !hasGithubWebhookTrigger(t.Task.Trigger) {
-			continue
-		}
-
-		mm := map[int][]*gojq.Code{}
-		for idxHook, hook := range t.Task.Trigger.Webhook.Github {
-			var filters []*gojq.Code
-			for idxFilter, filter := range hook.Filters {
-				query, err := gojq.Parse(filter)
-				if err != nil {
-					return fmt.Errorf("parse jq expression of GitHub webhook %d item %d: %w", idxHook, idxFilter, err)
-				}
-
-				compiledQuery, err := gojq.Compile(query)
-				if err != nil {
-					return fmt.Errorf("compile jq expression of GitHub webhook %d item %d: %w", idxHook, idxFilter, err)
-				}
-				filters = append(filters, compiledQuery)
+	s.githubTriggerCache = map[string][]cacheEntry{}
+	for _, t := range s.taskRegistry.GetTasks() {
+		if hasGithubWebhookTrigger(t.Trigger) {
+			err := s.populateGithubCache(t)
+			if err != nil {
+				return err
 			}
-
-			mm[idxHook] = filters
 		}
 
-		m[t.Task.Name] = mm
+		if hasGitlabWebhookTrigger(t.Trigger) {
+			err := s.populateGitlabCache(t)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
-	s.githubFilterCache = m
 	return nil
 }
 
-func (s *WebhookService) match(event string, idx int, taskName string, trigger schema.GithubTrigger, payload any) bool {
-	if ptr.From(trigger.Event) != event {
-		return false
+func (s *WebhookService) populateGithubCache(t *task.Task) error {
+	cacheEntries := make([]cacheEntry, len(t.Trigger.Webhook.Github))
+	for idxHook, hook := range t.Trigger.Webhook.Github {
+		filters, err := parseHookFilters(hook.Filters)
+		if err != nil {
+			return fmt.Errorf("parse GitHub webhook %d: %w", idxHook, err)
+		}
+
+		cacheEntries[idxHook] = cacheEntry{event: ptr.From(hook.Event), filters: filters}
 	}
 
-	filters := s.githubFilterCache[taskName][idx]
-	for _, f := range filters {
-		valueRaw, hasNext := f.Run(payload).Next()
-		if !hasNext {
-			return false
+	s.githubTriggerCache[t.Name] = cacheEntries
+	return nil
+}
+
+func (s *WebhookService) populateGitlabCache(t *task.Task) error {
+	cacheEntries := make([]cacheEntry, len(t.Trigger.Webhook.Gitlab))
+	for idxHook, hook := range t.Trigger.Webhook.Gitlab {
+		filters, err := parseHookFilters(hook.Filters)
+		if err != nil {
+			return fmt.Errorf("parse GitLab webhook %d: %w", idxHook, err)
 		}
 
-		if valueRaw == nil {
-			// Query matched nothing.
-			return false
-		}
-
-		value, ok := valueRaw.(bool)
-		if !ok {
-			// If valueRaw isn't of type bool,
-			// then the query returned an object or the value of a field.
-			// Example query: '.repository.full_name' returns a string
-			// Consider this a match.
-			continue
-		}
-
-		if !value {
-			return false
-		}
+		cacheEntries[idxHook] = cacheEntry{event: ptr.From(hook.Event), filters: filters}
 	}
 
-	return true
+	s.githubTriggerCache[t.Name] = cacheEntries
+	return nil
 }
 
 func hasGithubWebhookTrigger(trigger *schema.TaskTrigger) bool {
@@ -151,4 +132,71 @@ func hasGithubWebhookTrigger(trigger *schema.TaskTrigger) bool {
 	}
 
 	return true
+}
+
+func hasGitlabWebhookTrigger(trigger *schema.TaskTrigger) bool {
+	if trigger == nil {
+		return false
+	}
+
+	if trigger.Webhook == nil {
+		return false
+	}
+
+	if len(trigger.Webhook.Gitlab) == 0 {
+		return false
+	}
+
+	return true
+}
+
+func match(event string, trigger cacheEntry, payload any) bool {
+	if event != trigger.event {
+		return false
+	}
+
+	for _, f := range trigger.filters {
+		valueRaw, hasNext := f.Run(payload).Next()
+		if !hasNext {
+			return false
+		}
+
+		if valueRaw == nil {
+			// Query matched nothing.
+			return false
+		}
+
+		value, ok := valueRaw.(bool)
+		if !ok {
+			// Query doesn't return a boolean.
+			return false
+		}
+
+		if !value {
+			// Query evaluated to false.
+			return false
+		}
+	}
+
+	// All queries returned true.
+	// It's a match!
+	return true
+}
+
+func parseHookFilters(filters []string) ([]*gojq.Code, error) {
+	var codes []*gojq.Code
+	for idxFilter, filter := range filters {
+		query, err := gojq.Parse(filter)
+		if err != nil {
+			return nil, fmt.Errorf("parse jq expression of item %d: %w", idxFilter, err)
+		}
+
+		compiledQuery, err := gojq.Compile(query)
+		if err != nil {
+			return nil, fmt.Errorf("compile jq expression of item %d: %w", idxFilter, err)
+		}
+		codes = append(codes, compiledQuery)
+	}
+
+	return codes, nil
 }

--- a/pkg/task/schema/schema.go
+++ b/pkg/task/schema/schema.go
@@ -122,6 +122,18 @@ type GithubTrigger struct {
 	Filters []string `json:"filters,omitempty" yaml:"filters,omitempty" mapstructure:"filters,omitempty"`
 }
 
+type GitlabTrigger struct {
+	// Experimental: GitLab webhook event, like push. See
+	// https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html for a
+	// list of all available events.
+	Event *string `json:"event,omitempty" yaml:"event,omitempty" mapstructure:"event,omitempty"`
+
+	// Experimental: jq expressions to apply to the body of the webhook. If all
+	// expressions match the content of the webhook then a new run of the task is
+	// scheduled.
+	Filters []string `json:"filters,omitempty" yaml:"filters,omitempty" mapstructure:"filters,omitempty"`
+}
+
 // A plugin extends saturn-bot and allows custom filtering or modification of
 // repositories.
 type Plugin struct {
@@ -263,6 +275,9 @@ type TaskTrigger struct {
 type TaskTriggerWebhook struct {
 	// Experimental: Execute the task when the server receives a webhook from GitHub.
 	Github []GithubTrigger `json:"github,omitempty" yaml:"github,omitempty" mapstructure:"github,omitempty"`
+
+	// Experimental: Execute the task when the server receives a webhook from GitLab.
+	Gitlab []GitlabTrigger `json:"gitlab,omitempty" yaml:"gitlab,omitempty" mapstructure:"gitlab,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/task/schema/task.schema.json
+++ b/pkg/task/schema/task.schema.json
@@ -135,6 +135,13 @@
               "items": {
                 "$ref": "#/$defs/githubTrigger"
               }
+            },
+            "gitlab": {
+              "description": "Experimental: Execute the task when the server receives a webhook from GitLab.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/gitlabTrigger"
+              }
             }
           }
         }
@@ -199,6 +206,22 @@
       "properties": {
         "event": {
           "description": "Experimental: GitHub webhook event, like push. See https://docs.github.com/en/webhooks/webhook-events-and-payloads for a list of all available events.",
+          "type": "string"
+        },
+        "filters": {
+          "description": "Experimental: jq expressions to apply to the body of the webhook. If all expressions match the content of the webhook then a new run of the task is scheduled.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "gitlabTrigger": {
+      "type": "object",
+      "properties": {
+        "event": {
+          "description": "Experimental: GitLab webhook event, like push. See https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html for a list of all available events.",
           "type": "string"
         },
         "filters": {

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -104,6 +104,7 @@ type Task struct {
 	checksum               string
 	filters                []filter.Filter
 	openPRs                int
+	path                   string // Path to the file that contains the task.
 	plugins                []*plugin.Plugin
 	schedule               cron.Schedule
 	templateBranchName     *htmlTemplate.Template
@@ -270,6 +271,10 @@ func (tw *Task) OnPrMerged(ctx context.Context) error {
 	return nil
 }
 
+func (tw *Task) Path() string {
+	return tw.path
+}
+
 func (tw *Task) Stop() {
 	for _, p := range tw.plugins {
 		p.Stop()
@@ -336,7 +341,10 @@ func (tr *Registry) ReadTasks(taskFile string) error {
 			continue
 		}
 
-		wrapper := &Task{}
+		wrapper := &Task{
+			checksum: entry.Sha256,
+			path:     entry.Path,
+		}
 		wrapper.Task = entry.Task
 		wrapper.actions, err = createActionsForTask(wrapper.Task.Actions, tr.actionFactories, entry.Path)
 		if err != nil {
@@ -369,7 +377,6 @@ func (tr *Registry) ReadTasks(taskFile string) error {
 		}
 		wrapper.schedule = schedule
 
-		wrapper.checksum = entry.Sha256
 		tr.tasks = append(tr.tasks, wrapper)
 	}
 


### PR DESCRIPTION
- Add endpoint that accepts webhooks sent by GitLab.
- Add integration tests for the feature.
- Make server code use `task.Registry` everywhere.