### PR TITLE
feat(server): Inspect upcoming and past runs via an endpoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+pkg/server/api/openapi/server.gen.go linguist-generated=true
+pkg/worker/client/openapi.gen.go linguist-generated=true

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -1,0 +1,31 @@
+package clock
+
+import "time"
+
+var (
+	Default = defaultClock{}
+)
+
+type Clock interface {
+	Now() time.Time
+}
+
+type defaultClock struct{}
+
+func (dc defaultClock) Now() time.Time {
+	return time.Now()
+}
+
+type Fake struct {
+	Base time.Time
+}
+
+// Now fakes the current time.
+// It returns whatever base value to clock currently contains.
+// It increases the base value by one second for each call
+// to make it possible to check a sequence of calls.
+func (fc *Fake) Now() time.Time {
+	now := fc.Base
+	fc.Base = fc.Base.Add(1 * time.Second)
+	return now
+}

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -3,9 +3,11 @@ package clock
 import "time"
 
 var (
+	// Default is a proxy to the [time] package.
 	Default = defaultClock{}
 )
 
+// Clock defines methods of a clock.
 type Clock interface {
 	Now() time.Time
 }
@@ -16,6 +18,8 @@ func (dc defaultClock) Now() time.Time {
 	return time.Now()
 }
 
+// Fake fakes the clock.
+// Useful in tests.
 type Fake struct {
 	Base time.Time
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/wndhydrnt/saturn-bot/pkg/action"
+	"github.com/wndhydrnt/saturn-bot/pkg/clock"
 	"github.com/wndhydrnt/saturn-bot/pkg/config"
 	"github.com/wndhydrnt/saturn-bot/pkg/filter"
 	"github.com/wndhydrnt/saturn-bot/pkg/host"
@@ -49,6 +50,7 @@ func (ff FilterFactories) Find(name string) filter.Factory {
 
 type Opts struct {
 	ActionFactories      ActionFactories
+	Clock                clock.Clock
 	Config               config.Configuration
 	FilterFactories      FilterFactories
 	Hosts                []host.Host
@@ -174,6 +176,10 @@ func Initialize(opts *Opts) error {
 		metrics.Register(opts.PrometheusRegisterer)
 		opts.PushGateway = push.New(*opts.Config.PrometheusPushgatewayUrl, "saturn-bot").
 			Gatherer(opts.PrometheusGatherer)
+	}
+
+	if opts.Clock == nil {
+		opts.Clock = clock.Default
 	}
 
 	return nil

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -49,7 +49,10 @@ func (ff FilterFactories) Find(name string) filter.Factory {
 }
 
 type Opts struct {
-	ActionFactories      ActionFactories
+	ActionFactories ActionFactories
+	// Clock interfaces to a clock.
+	// Its purpose is to fake time in unit tests.
+	// Defaults to an object that proxies to the [time] package.
 	Clock                clock.Clock
 	Config               config.Configuration
 	FilterFactories      FilterFactories

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
+	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
+	"github.com/wndhydrnt/saturn-bot/pkg/server/service"
 	"gopkg.in/yaml.v3"
 )
 
@@ -72,4 +74,24 @@ func DiscardRequest(r *http.Request) {
 	if err := r.Body.Close(); err != nil {
 		log.Log().Debug("Failed to close request body")
 	}
+}
+
+func toListOptions(apiListOpts *openapi.ListOptions) service.ListOptions {
+	if apiListOpts == nil {
+		return service.ListOptions{Limit: 20, Page: 1}
+	}
+
+	listOpts := service.ListOptions{
+		Limit: apiListOpts.Limit,
+		Page:  apiListOpts.Page,
+	}
+	if apiListOpts.Limit == 0 {
+		listOpts.Limit = 20
+	}
+
+	if apiListOpts.Page == 0 {
+		listOpts.Page = 1
+	}
+
+	return listOpts
 }

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -85,8 +85,12 @@ func toListOptions(apiListOpts *openapi.ListOptions) service.ListOptions {
 		Limit: apiListOpts.Limit,
 		Page:  apiListOpts.Page,
 	}
-	if apiListOpts.Limit == 0 {
+	if apiListOpts.Limit <= 0 {
 		listOpts.Limit = 20
+	}
+
+	if apiListOpts.Limit > 50 {
+		listOpts.Limit = 50
 	}
 
 	if apiListOpts.Page == 0 {

--- a/pkg/server/api/apiserver.go
+++ b/pkg/server/api/apiserver.go
@@ -4,12 +4,14 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/wndhydrnt/saturn-bot/pkg/clock"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/service"
 )
 
 // APIServer provides the implementation of the OpenAPI endpoints.
 type APIServer struct {
+	Clock         clock.Clock
 	TaskService   *service.TaskService
 	WorkerService *service.WorkerService
 }

--- a/pkg/server/api/error.go
+++ b/pkg/server/api/error.go
@@ -1,0 +1,7 @@
+package api
+
+import "errors"
+
+var (
+	ErrInternal = errors.New("internal server error")
+)

--- a/pkg/server/api/openapi/openapi.yaml
+++ b/pkg/server/api/openapi/openapi.yaml
@@ -70,6 +70,32 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /api/v1/tasks/{task}/runs:
+    get:
+      operationId: listTaskRunsV1
+      summary: List of scheduled runs of a task.
+      description: |
+        Returns a list of past and future runs of a task.
+      tags:
+        - task
+      parameters:
+        - in: path
+          name: task
+          schema:
+            type: string
+          required: true
+          description: Name of the task for which to return the runs.
+        - in: query
+          name: listOptions
+          schema:
+            $ref: "#/components/schemas/ListOptions"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListTaskRunsV1Response"
   /api/v1/worker/work:
     get:
       operationId: getWorkV1
@@ -230,3 +256,54 @@ components:
         content:
           type: string
       required: ["name", "hash", "content"]
+    ListOptions:
+      type: object
+      properties:
+        page:
+          default: 1
+          type: integer
+        limit:
+          default: 20
+          type: integer
+      required: ["page", "limit"]
+    Page:
+      type: object
+      properties:
+        next:
+          type: integer
+      required: ["next"]
+    ListTaskRunsV1Response:
+      type: object
+      properties:
+        result:
+          type: array
+          description: List of runs.
+          items:
+            $ref: "#/components/schemas/TaskRunV1"
+        page:
+          $ref: "#/components/schemas/Page"
+      required: ["result", "page"]
+    TaskRunV1:
+      type: object
+      properties:
+        id:
+          type: integer
+        reason:
+          type: string
+          enum:
+            - changed
+            - manual
+            - new
+            - next
+            - webhook
+        scheduleAfter:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum:
+            - pending
+            - running
+            - finished
+            - failed
+      required: ["id", "reason", "scheduleAfter", "status"]

--- a/pkg/server/api/openapi/openapi.yaml
+++ b/pkg/server/api/openapi/openapi.yaml
@@ -292,6 +292,7 @@ components:
           type: string
           format: date-time
         id:
+          x-go-type: uint
           type: integer
         reason:
           type: string

--- a/pkg/server/api/openapi/openapi.yaml
+++ b/pkg/server/api/openapi/openapi.yaml
@@ -70,32 +70,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /api/v1/tasks/{task}/runs:
-    get:
-      operationId: listTaskRunsV1
-      summary: List of scheduled runs of a task.
-      description: |
-        Returns a list of past and future runs of a task.
-      tags:
-        - task
-      parameters:
-        - in: path
-          name: task
-          schema:
-            type: string
-          required: true
-          description: Name of the task for which to return the runs.
-        - in: query
-          name: listOptions
-          schema:
-            $ref: "#/components/schemas/ListOptions"
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ListTaskRunsV1Response"
   /api/v1/worker/work:
     get:
       operationId: getWorkV1
@@ -129,6 +103,32 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReportWorkV1Response"
+  /api/v1/worker/runs:
+    get:
+      operationId: listRunsV1
+      summary: List of runs.
+      description: |
+        Returns a list of past and future runs.
+        Optional filters can be applied.
+      tags:
+        - worker
+      parameters:
+        - in: query
+          name: task
+          schema:
+            type: string
+          description: Name of the task to filter by.
+        - in: query
+          name: listOptions
+          schema:
+            $ref: "#/components/schemas/ListOptions"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListRunsV1Response"
 components:
   schemas:
     ScheduleRunV1Request:
@@ -265,6 +265,8 @@ components:
         limit:
           default: 20
           type: integer
+          minimum: 1
+          maximum: 50
       required: ["page", "limit"]
     Page:
       type: object
@@ -272,20 +274,23 @@ components:
         next:
           type: integer
       required: ["next"]
-    ListTaskRunsV1Response:
+    ListRunsV1Response:
       type: object
       properties:
         result:
           type: array
           description: List of runs.
           items:
-            $ref: "#/components/schemas/TaskRunV1"
+            $ref: "#/components/schemas/RunV1"
         page:
           $ref: "#/components/schemas/Page"
       required: ["result", "page"]
-    TaskRunV1:
+    RunV1:
       type: object
       properties:
+        finishedAt:
+          type: string
+          format: date-time
         id:
           type: integer
         reason:
@@ -296,7 +301,14 @@ components:
             - new
             - next
             - webhook
+        repositories:
+          type: array
+          items:
+            type: string
         scheduleAfter:
+          type: string
+          format: date-time
+        startedAt:
           type: string
           format: date-time
         status:
@@ -306,4 +318,6 @@ components:
             - running
             - finished
             - failed
-      required: ["id", "reason", "scheduleAfter", "status"]
+        task:
+          type: string
+      required: ["id", "reason", "scheduleAfter", "status", "task"]

--- a/pkg/server/api/openapi/server.gen.go
+++ b/pkg/server/api/openapi/server.gen.go
@@ -135,7 +135,7 @@ type ReportWorkV1TaskResult struct {
 // RunV1 defines model for RunV1.
 type RunV1 struct {
 	FinishedAt    *time.Time  `json:"finishedAt,omitempty"`
-	Id            int         `json:"id"`
+	Id            uint        `json:"id"`
 	Reason        RunV1Reason `json:"reason"`
 	Repositories  *[]string   `json:"repositories,omitempty"`
 	ScheduleAfter time.Time   `json:"scheduleAfter"`

--- a/pkg/server/api/task.go
+++ b/pkg/server/api/task.go
@@ -3,10 +3,7 @@ package api
 import (
 	"context"
 
-	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
-	"github.com/wndhydrnt/saturn-bot/pkg/server/db"
-	"go.uber.org/zap"
 )
 
 // GetTaskV1 implements [openapi.ServerInterface].
@@ -36,63 +33,4 @@ func (th *APIServer) ListTasksV1(_ context.Context, request openapi.ListTasksV1R
 	}
 
 	return resp, nil
-}
-
-func (a *APIServer) ListTaskRunsV1(_ context.Context, request openapi.ListTaskRunsV1RequestObject) (openapi.ListTaskRunsV1ResponseObject, error) {
-	listOpts := toListOptions(request.Params.ListOptions)
-	runs, totalCount, err := a.WorkerService.ListRunsOfTask(request.Task, listOpts)
-	if err != nil {
-		log.Log().Errorw("Failed to list runs of task", zap.Error(err))
-		return nil, ErrInternal
-	}
-
-	result := make([]openapi.TaskRunV1, len(runs))
-	for idx, run := range runs {
-		result[idx] = mapRun(run)
-	}
-
-	resp := openapi.ListTaskRunsV1200JSONResponse{
-		Page: openapi.Page{
-			Next: listOpts.Next(int(totalCount)),
-		},
-		Result: result,
-	}
-	return resp, nil
-}
-
-func mapRun(r db.Run) openapi.TaskRunV1 {
-	return openapi.TaskRunV1{
-		Id:            int(r.ID),
-		Reason:        mapRunReason(r.Reason),
-		ScheduleAfter: r.ScheduleAfter,
-		Status:        mapRunStatus(r.Status),
-	}
-}
-
-func mapRunReason(r db.RunReason) openapi.TaskRunV1Reason {
-	switch r {
-	case db.RunReasonChanged:
-		return openapi.Changed
-	case db.RunReasonManual:
-		return openapi.Manual
-	case db.RunReasonNew:
-		return openapi.New
-	case db.RunReasonWebhook:
-		return openapi.Webhook
-	default:
-		return openapi.Next
-	}
-}
-
-func mapRunStatus(s db.RunStatus) openapi.TaskRunV1Status {
-	switch s {
-	case db.RunStatusFailed:
-		return openapi.Failed
-	case db.RunStatusFinished:
-		return openapi.Finished
-	case db.RunStatusRunning:
-		return openapi.Running
-	default:
-		return openapi.Pending
-	}
 }

--- a/pkg/server/api/task.go
+++ b/pkg/server/api/task.go
@@ -3,7 +3,10 @@ package api
 import (
 	"context"
 
+	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
+	"github.com/wndhydrnt/saturn-bot/pkg/server/db"
+	"go.uber.org/zap"
 )
 
 // GetTaskV1 implements [openapi.ServerInterface].
@@ -33,4 +36,63 @@ func (th *APIServer) ListTasksV1(_ context.Context, request openapi.ListTasksV1R
 	}
 
 	return resp, nil
+}
+
+func (a *APIServer) ListTaskRunsV1(_ context.Context, request openapi.ListTaskRunsV1RequestObject) (openapi.ListTaskRunsV1ResponseObject, error) {
+	listOpts := toListOptions(request.Params.ListOptions)
+	runs, totalCount, err := a.WorkerService.ListRunsOfTask(request.Task, listOpts)
+	if err != nil {
+		log.Log().Errorw("Failed to list runs of task", zap.Error(err))
+		return nil, ErrInternal
+	}
+
+	result := make([]openapi.TaskRunV1, len(runs))
+	for idx, run := range runs {
+		result[idx] = mapRun(run)
+	}
+
+	resp := openapi.ListTaskRunsV1200JSONResponse{
+		Page: openapi.Page{
+			Next: listOpts.Next(int(totalCount)),
+		},
+		Result: result,
+	}
+	return resp, nil
+}
+
+func mapRun(r db.Run) openapi.TaskRunV1 {
+	return openapi.TaskRunV1{
+		Id:            int(r.ID),
+		Reason:        mapRunReason(r.Reason),
+		ScheduleAfter: r.ScheduleAfter,
+		Status:        mapRunStatus(r.Status),
+	}
+}
+
+func mapRunReason(r db.RunReason) openapi.TaskRunV1Reason {
+	switch r {
+	case db.RunReasonChanged:
+		return openapi.Changed
+	case db.RunReasonManual:
+		return openapi.Manual
+	case db.RunReasonNew:
+		return openapi.New
+	case db.RunReasonWebhook:
+		return openapi.Webhook
+	default:
+		return openapi.Next
+	}
+}
+
+func mapRunStatus(s db.RunStatus) openapi.TaskRunV1Status {
+	switch s {
+	case db.RunStatusFailed:
+		return openapi.Failed
+	case db.RunStatusFinished:
+		return openapi.Finished
+	case db.RunStatusRunning:
+		return openapi.Running
+	default:
+		return openapi.Pending
+	}
 }

--- a/pkg/server/api/work.go
+++ b/pkg/server/api/work.go
@@ -101,7 +101,7 @@ func (a *APIServer) ScheduleRunV1(_ context.Context, req openapi.ScheduleRunV1Re
 func mapRun(r db.Run) openapi.RunV1 {
 	run := openapi.RunV1{
 		FinishedAt:    r.FinishedAt,
-		Id:            int(r.ID),
+		Id:            r.ID,
 		Reason:        mapRunReason(r.Reason),
 		ScheduleAfter: r.ScheduleAfter,
 		StartedAt:     r.StartedAt,

--- a/pkg/server/api/work.go
+++ b/pkg/server/api/work.go
@@ -37,6 +37,33 @@ func (a *APIServer) GetWorkV1(ctx context.Context, _ openapi.GetWorkV1RequestObj
 	return resp, nil
 }
 
+func (a *APIServer) ListRunsV1(ctx context.Context, request openapi.ListRunsV1RequestObject) (openapi.ListRunsV1ResponseObject, error) {
+	listOpts := toListOptions(request.Params.ListOptions)
+	queryOpts := service.ListRunsOptions{}
+	if request.Params.Task != nil {
+		queryOpts.TaskName = ptr.From(request.Params.Task)
+	}
+
+	runs, totalCount, err := a.WorkerService.ListRuns(queryOpts, listOpts)
+	if err != nil {
+		log.Log().Errorw("Failed to list runs of task", zap.Error(err))
+		return nil, ErrInternal
+	}
+
+	result := make([]openapi.RunV1, len(runs))
+	for idx, run := range runs {
+		result[idx] = mapRun(run)
+	}
+
+	resp := openapi.ListRunsV1200JSONResponse{
+		Page: openapi.Page{
+			Next: listOpts.Next(int(totalCount)),
+		},
+		Result: result,
+	}
+	return resp, nil
+}
+
 func (a *APIServer) ReportWorkV1(_ context.Context, request openapi.ReportWorkV1RequestObject) (openapi.ReportWorkV1ResponseObject, error) {
 	resp := openapi.ReportWorkV1201JSONResponse{}
 	err := a.WorkerService.ReportRun(*request.Body)
@@ -69,4 +96,49 @@ func (a *APIServer) ScheduleRunV1(_ context.Context, req openapi.ScheduleRunV1Re
 	return openapi.ScheduleRunV1200JSONResponse{
 		RunID: int(runID), // #nosec G115 -- no info by gosec on how to fix this
 	}, nil
+}
+
+func mapRun(r db.Run) openapi.RunV1 {
+	run := openapi.RunV1{
+		FinishedAt:    r.FinishedAt,
+		Id:            int(r.ID),
+		Reason:        mapRunReason(r.Reason),
+		ScheduleAfter: r.ScheduleAfter,
+		StartedAt:     r.StartedAt,
+		Status:        mapRunStatus(r.Status),
+		Task:          r.TaskName,
+	}
+	if len(r.RepositoryNames) > 0 {
+		run.Repositories = ptr.To([]string(r.RepositoryNames))
+	}
+
+	return run
+}
+
+func mapRunReason(r db.RunReason) openapi.RunV1Reason {
+	switch r {
+	case db.RunReasonChanged:
+		return openapi.Changed
+	case db.RunReasonManual:
+		return openapi.Manual
+	case db.RunReasonNew:
+		return openapi.New
+	case db.RunReasonWebhook:
+		return openapi.Webhook
+	default:
+		return openapi.Next
+	}
+}
+
+func mapRunStatus(s db.RunStatus) openapi.RunV1Status {
+	switch s {
+	case db.RunStatusFailed:
+		return openapi.Failed
+	case db.RunStatusFinished:
+		return openapi.Finished
+	case db.RunStatusRunning:
+		return openapi.Running
+	default:
+		return openapi.Pending
+	}
 }

--- a/pkg/server/integration/integration_test.go
+++ b/pkg/server/integration/integration_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/ncruces/go-sqlite3/vfs/memdb"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"github.com/wndhydrnt/saturn-bot/pkg/clock"
 	"github.com/wndhydrnt/saturn-bot/pkg/config"
 	"github.com/wndhydrnt/saturn-bot/pkg/options"
 	"github.com/wndhydrnt/saturn-bot/pkg/ptr"
@@ -29,6 +30,7 @@ var (
 	defaultTask              = schema.Task{Name: "unittest"}
 	defaultTaskContentBase64 = "bmFtZTogdW5pdHRlc3QK"
 	defaultTaskHash          = "e42a6e186f31b860f22f07ed468b99c6dc75318542fc9ac8383358fae1b5ab8b"
+	fakeClock                = &clock.Fake{Base: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)}
 )
 
 type apiCall struct {
@@ -36,6 +38,8 @@ type apiCall struct {
 	method string
 	// Path of the request.
 	path string
+	// Query parameters of the request.
+	query string
 	// Request headers, if any.
 	requestHeaders map[string]string
 	// Request body, if any.
@@ -77,6 +81,9 @@ func executeTestCase(t *testing.T, tc testCase) {
 	promReg := prometheus.NewRegistry()
 	opts.SetPrometheusRegistry(promReg)
 
+	// Always add a fake clock make calls to Now() predictable.
+	opts.Clock = fakeClock
+
 	taskFiles := bootstrapTaskFiles(t, tc.tasks)
 
 	server := &server.Server{}
@@ -94,6 +101,9 @@ func executeTestCase(t *testing.T, tc testCase) {
 		time.Sleep(call.sleep)
 		req := e.Request(call.method, call.path).
 			WithHeaders(call.requestHeaders)
+		if call.query != "" {
+			req = req.WithQueryString(call.query)
+		}
 		if call.requestBody != nil {
 			req = req.WithJSON(call.requestBody)
 		}

--- a/pkg/server/integration/task_test.go
+++ b/pkg/server/integration/task_test.go
@@ -1,10 +1,8 @@
 package integration_test
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
 	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
@@ -63,78 +61,6 @@ func TestServer_API_GetTaskV1(t *testing.T) {
 					path:         "/api/v1/tasks/unknown",
 					statusCode:   http.StatusNotFound,
 					responseBody: openapi.Error{Error: "Not Found", Message: "Task unknown"},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			executeTestCase(t, tc)
-		})
-	}
-}
-
-func TestServer_API_ListTaskRunsV1(t *testing.T) {
-	testCases := []testCase{
-		{
-			name: `Given two runs of a task
-								When a request with limit=1&page=1 is sent
-								And a request with limit=1&page=2 is sent
-								Then it returns the latest run
-								And it returns the previous run`,
-			tasks: []schema.Task{defaultTask},
-			apiCalls: []apiCall{
-				// Read the run that gets scheduled at the start of the server.
-				{
-					method:     "GET",
-					path:       "/api/v1/worker/work",
-					statusCode: http.StatusOK,
-					responseBody: openapi.GetWorkV1Response{
-						RunID: 1,
-						Tasks: []openapi.GetWorkV1Task{
-							{Hash: defaultTaskHash, Name: defaultTask.Name},
-						},
-					},
-				},
-				// And report the result of the run.
-				{
-					method: "POST",
-					path:   "/api/v1/worker/work",
-					requestBody: openapi.ReportWorkV1Request{
-						RunID:       1,
-						TaskResults: []openapi.ReportWorkV1TaskResult{},
-					},
-					statusCode: http.StatusCreated,
-					responseBody: openapi.ReportWorkV1Response{
-						Result: "ok",
-					},
-				},
-				// List the runs of the task. Limit to one result to test pagination.
-				{
-					method:     "GET",
-					path:       fmt.Sprintf("/api/v1/tasks/%s/runs", defaultTask.Name),
-					query:      "limit=1&page=1",
-					statusCode: http.StatusOK,
-					responseBody: openapi.ListTaskRunsV1Response{
-						Page: openapi.Page{Next: 2},
-						Result: []openapi.TaskRunV1{
-							{Id: 2, Reason: openapi.Next, ScheduleAfter: time.Date(2000, 1, 1, 1, 0, 3, 0, time.UTC), Status: openapi.Pending},
-						},
-					},
-				},
-				// List the next page of runs.
-				{
-					method:     "GET",
-					path:       fmt.Sprintf("/api/v1/tasks/%s/runs", defaultTask.Name),
-					query:      "limit=1&page=2",
-					statusCode: http.StatusOK,
-					responseBody: openapi.ListTaskRunsV1Response{
-						Page: openapi.Page{Next: 0},
-						Result: []openapi.TaskRunV1{
-							{Id: 1, Reason: openapi.New, ScheduleAfter: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), Status: openapi.Finished},
-						},
-					},
 				},
 			},
 		},

--- a/pkg/server/integration/task_test.go
+++ b/pkg/server/integration/task_test.go
@@ -1,14 +1,16 @@
 package integration_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
 	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
 )
 
-func TestServer_TaskAPI(t *testing.T) {
+func TestServer_API_ListTasksV1(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:  `When it receives a request to list tasks then it returns the list of known tasks`,
@@ -24,7 +26,17 @@ func TestServer_TaskAPI(t *testing.T) {
 				},
 			},
 		},
+	}
 
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			executeTestCase(t, tc)
+		})
+	}
+}
+
+func TestServer_API_GetTaskV1(t *testing.T) {
+	testCases := []testCase{
 		{
 			name:  `When it receives a request to get one task and the task does exist then it returns the tasks`,
 			tasks: []schema.Task{defaultTask},
@@ -51,6 +63,78 @@ func TestServer_TaskAPI(t *testing.T) {
 					path:         "/api/v1/tasks/unknown",
 					statusCode:   http.StatusNotFound,
 					responseBody: openapi.Error{Error: "Not Found", Message: "Task unknown"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			executeTestCase(t, tc)
+		})
+	}
+}
+
+func TestServer_API_ListTaskRunsV1(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: `Given two runs of a task
+								When a request with limit=1&page=1 is sent
+								And a request with limit=1&page=2 is sent
+								Then it returns the latest run
+								And it returns the previous run`,
+			tasks: []schema.Task{defaultTask},
+			apiCalls: []apiCall{
+				// Read the run that gets scheduled at the start of the server.
+				{
+					method:     "GET",
+					path:       "/api/v1/worker/work",
+					statusCode: http.StatusOK,
+					responseBody: openapi.GetWorkV1Response{
+						RunID: 1,
+						Tasks: []openapi.GetWorkV1Task{
+							{Hash: defaultTaskHash, Name: defaultTask.Name},
+						},
+					},
+				},
+				// And report the result of the run.
+				{
+					method: "POST",
+					path:   "/api/v1/worker/work",
+					requestBody: openapi.ReportWorkV1Request{
+						RunID:       1,
+						TaskResults: []openapi.ReportWorkV1TaskResult{},
+					},
+					statusCode: http.StatusCreated,
+					responseBody: openapi.ReportWorkV1Response{
+						Result: "ok",
+					},
+				},
+				// List the runs of the task. Limit to one result to test pagination.
+				{
+					method:     "GET",
+					path:       fmt.Sprintf("/api/v1/tasks/%s/runs", defaultTask.Name),
+					query:      "limit=1&page=1",
+					statusCode: http.StatusOK,
+					responseBody: openapi.ListTaskRunsV1Response{
+						Page: openapi.Page{Next: 2},
+						Result: []openapi.TaskRunV1{
+							{Id: 2, Reason: openapi.Next, ScheduleAfter: time.Date(2000, 1, 1, 1, 0, 3, 0, time.UTC), Status: openapi.Pending},
+						},
+					},
+				},
+				// List the next page of runs.
+				{
+					method:     "GET",
+					path:       fmt.Sprintf("/api/v1/tasks/%s/runs", defaultTask.Name),
+					query:      "limit=1&page=2",
+					statusCode: http.StatusOK,
+					responseBody: openapi.ListTaskRunsV1Response{
+						Page: openapi.Page{Next: 0},
+						Result: []openapi.TaskRunV1{
+							{Id: 1, Reason: openapi.New, ScheduleAfter: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), Status: openapi.Finished},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/server/integration/work_test.go
+++ b/pkg/server/integration/work_test.go
@@ -1,0 +1,98 @@
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/wndhydrnt/saturn-bot/pkg/ptr"
+	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
+	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
+)
+
+func TestServer_API_ListRunsV1(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: `Given two runs of a task
+								When a request with limit=1&page=1 is sent
+								And a request with limit=1&page=2 is sent
+								Then it returns the latest run
+								And it returns the previous run`,
+			tasks: []schema.Task{defaultTask},
+			apiCalls: []apiCall{
+				// Read the run that gets scheduled at the start of the server.
+				{
+					method:     "GET",
+					path:       "/api/v1/worker/work",
+					statusCode: http.StatusOK,
+					responseBody: openapi.GetWorkV1Response{
+						RunID: 1,
+						Tasks: []openapi.GetWorkV1Task{
+							{Hash: defaultTaskHash, Name: defaultTask.Name},
+						},
+					},
+				},
+				// And report the result of the run.
+				{
+					method: "POST",
+					path:   "/api/v1/worker/work",
+					requestBody: openapi.ReportWorkV1Request{
+						RunID:       1,
+						TaskResults: []openapi.ReportWorkV1TaskResult{},
+					},
+					statusCode: http.StatusCreated,
+					responseBody: openapi.ReportWorkV1Response{
+						Result: "ok",
+					},
+				},
+				// List the runs of the task. Limit to one result to test pagination.
+				{
+					method:     "GET",
+					path:       "/api/v1/worker/runs",
+					query:      fmt.Sprintf("limit=1&page=1&task=%s", defaultTask.Name),
+					statusCode: http.StatusOK,
+					responseBody: openapi.ListRunsV1Response{
+						Page: openapi.Page{Next: 2},
+						Result: []openapi.RunV1{
+							{
+								Id:            2,
+								Reason:        openapi.Next,
+								ScheduleAfter: time.Date(2000, 1, 1, 1, 0, 41, 0, time.UTC),
+								Status:        openapi.Pending,
+								Task:          defaultTask.Name,
+							},
+						},
+					},
+				},
+				// List the next page of runs.
+				{
+					method:     "GET",
+					path:       "/api/v1/worker/runs",
+					query:      fmt.Sprintf("limit=1&page=2&task=%s", defaultTask.Name),
+					statusCode: http.StatusOK,
+					responseBody: openapi.ListRunsV1Response{
+						Page: openapi.Page{Next: 0},
+						Result: []openapi.RunV1{
+							{
+								FinishedAt:    ptr.To(time.Date(2000, 1, 1, 0, 0, 40, 0, time.UTC)),
+								Id:            1,
+								Reason:        openapi.New,
+								ScheduleAfter: time.Date(2000, 1, 1, 0, 0, 37, 0, time.UTC),
+								StartedAt:     ptr.To(time.Date(2000, 1, 1, 0, 0, 39, 0, time.UTC)),
+								Status:        openapi.Finished,
+								Task:          defaultTask.Name,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			executeTestCase(t, tc)
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,15 +52,15 @@ func (s *Server) Start(opts options.Opts, taskPaths []string) error {
 		return fmt.Errorf("initialize database: %w", err)
 	}
 
-	taskService := service.NewTaskService(database, taskRegistry)
+	taskService := service.NewTaskService(opts.Clock, database, taskRegistry)
 	err = taskService.SyncDbTasks()
 	if err != nil {
 		return err
 	}
 
-	workerService := service.NewWorkerService(database, taskRegistry)
+	workerService := service.NewWorkerService(opts.Clock, database, taskRegistry)
 	router := newRouter(opts)
-	webhookService, err := service.NewWebhookService(taskRegistry, workerService)
+	webhookService, err := service.NewWebhookService(opts.Clock, taskRegistry, workerService)
 	if err != nil {
 		return fmt.Errorf("create webhook service: %w", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -88,6 +88,7 @@ func (s *Server) Start(opts options.Opts, taskPaths []string) error {
 	}
 	s.httpServer.Handler = handler
 	go func(server *http.Server) {
+		log.Log().Infof("HTTP server listening on %s", opts.Config.ServerAddr)
 		err := server.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Log().Errorw("HTTP server failed - exiting", zap.Error(err))

--- a/pkg/server/service/listoptions.go
+++ b/pkg/server/service/listoptions.go
@@ -1,0 +1,18 @@
+package service
+
+type ListOptions struct {
+	Limit int
+	Page  int
+}
+
+func (lo ListOptions) Offset() int {
+	return (lo.Limit * lo.Page) - lo.Limit
+}
+
+func (lo ListOptions) Next(count int) int {
+	if (lo.Limit * lo.Page) < count {
+		return lo.Page + 1
+	}
+
+	return 0
+}

--- a/pkg/server/service/taskservice.go
+++ b/pkg/server/service/taskservice.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
+	"github.com/wndhydrnt/saturn-bot/pkg/clock"
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
 	"github.com/wndhydrnt/saturn-bot/pkg/server/db"
 	"github.com/wndhydrnt/saturn-bot/pkg/task"
@@ -14,12 +14,17 @@ import (
 )
 
 type TaskService struct {
+	clock        clock.Clock
 	db           *gorm.DB
 	taskRegistry *task.Registry
 }
 
-func NewTaskService(db *gorm.DB, taskRegistry *task.Registry) *TaskService {
-	return &TaskService{db: db, taskRegistry: taskRegistry}
+func NewTaskService(clock clock.Clock, db *gorm.DB, taskRegistry *task.Registry) *TaskService {
+	return &TaskService{
+		clock:        clock,
+		db:           db,
+		taskRegistry: taskRegistry,
+	}
 }
 
 func (ts *TaskService) SyncDbTasks() error {
@@ -40,8 +45,8 @@ func (ts *TaskService) SyncDbTasks() error {
 				}
 
 				run := db.Run{
-					Reason:        0,
-					ScheduleAfter: time.Now(),
+					Reason:        db.RunReasonNew,
+					ScheduleAfter: ts.clock.Now(),
 					Status:        db.RunStatusPending,
 					TaskName:      t.Name,
 				}
@@ -60,7 +65,7 @@ func (ts *TaskService) SyncDbTasks() error {
 				log.Log().Debugf("Updating task %s in DB", taskDB.Name)
 				run := db.Run{
 					Reason:        0,
-					ScheduleAfter: time.Now(),
+					ScheduleAfter: ts.clock.Now(),
 					Status:        db.RunStatusPending,
 					TaskName:      t.Name,
 				}

--- a/pkg/worker/client/openapi.gen.go
+++ b/pkg/worker/client/openapi.gen.go
@@ -137,7 +137,7 @@ type ReportWorkV1TaskResult struct {
 // RunV1 defines model for RunV1.
 type RunV1 struct {
 	FinishedAt    *time.Time  `json:"finishedAt,omitempty"`
-	Id            int         `json:"id"`
+	Id            uint        `json:"id"`
 	Reason        RunV1Reason `json:"reason"`
 	Repositories  *[]string   `json:"repositories,omitempty"`
 	ScheduleAfter time.Time   `json:"scheduleAfter"`


### PR DESCRIPTION
- Add an endpoint that returns all runs. Ais in debugging.
- Support pagination in endpoints via generic `ListOptions` struct.
- Add package `clock` to fake `time.Now()` in tests.