### PR TITLE
fix(processor): Pull request not recreated if closed

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -156,9 +156,14 @@ func applyTaskToRepository(ctx context.Context, dryRun bool, gitc git.GitClient,
 		return ResultUnknown, fmt.Errorf("find pull request: %w", err)
 	}
 
-	if prID != nil && repo.IsPullRequestClosed(prID) && task.MergeOnce {
-		logger.Info("Existing PR has been closed")
-		return ResultPrClosedBefore, nil
+	if prID != nil && repo.IsPullRequestClosed(prID) {
+		if task.MergeOnce {
+			logger.Info("Existing PR has been closed")
+			return ResultPrClosedBefore, nil
+		} else {
+			logger.Debug("Previous pull request closed - resetting to create a new pull request")
+			prID = nil
+		}
 	}
 
 	if prID != nil && repo.IsPullRequestMerged(prID) && task.MergeOnce {


### PR DESCRIPTION
If `mergeOnce` is deactivated
and the existing pull request is closed
and the branch of the existing pull request isn't deleted at the host
then it recreates the merge request.