### PR TITLE
refactor(host): Unify code that creates a repository from a name

### DIFF
--- a/pkg/command/hostmock_test.go
+++ b/pkg/command/hostmock_test.go
@@ -465,6 +465,21 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
 }
 
+// AuthenticatedUser mocks base method.
+func (m *MockHost) AuthenticatedUser() (*host.UserInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthenticatedUser")
+	ret0, _ := ret[0].(*host.UserInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthenticatedUser indicates an expected call of AuthenticatedUser.
+func (mr *MockHostMockRecorder) AuthenticatedUser() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticatedUser", reflect.TypeOf((*MockHost)(nil).AuthenticatedUser))
+}
+
 // CreateFromName mocks base method.
 func (m *MockHost) CreateFromName(name string) (host.Repository, error) {
 	m.ctrl.T.Helper()
@@ -502,6 +517,20 @@ func (m *MockHost) ListRepositoriesWithOpenPullRequests(result chan []host.Repos
 func (mr *MockHostMockRecorder) ListRepositoriesWithOpenPullRequests(result, errChan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositoriesWithOpenPullRequests", reflect.TypeOf((*MockHost)(nil).ListRepositoriesWithOpenPullRequests), result, errChan)
+}
+
+// Name mocks base method.
+func (m *MockHost) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHostMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHost)(nil).Name))
 }
 
 // MockHostDetail is a mock of HostDetail interface.

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -284,7 +284,7 @@ func discoverRepositoriesFromCLI(
 	log.Log().Info("Discovering repositories from CLI")
 	go func() {
 		for _, repoName := range repositoryNames {
-			repo, err := findRepositoryInHosts(hosts, repoName)
+			repo, err := host.NewRepositoryFromName(hosts, repoName)
 			if err != nil {
 				errChan <- err
 				return
@@ -296,22 +296,6 @@ func discoverRepositoriesFromCLI(
 		errChan <- nil
 	}()
 	return 1
-}
-
-// findRepositoryInHosts queries all hosts to find the given repository, identified by its name.
-func findRepositoryInHosts(hosts []host.Host, repositoryName string) (host.Repository, error) {
-	for _, h := range hosts {
-		repo, err := h.CreateFromName(repositoryName)
-		if err != nil {
-			return nil, err
-		}
-
-		if repo != nil {
-			return repo, nil
-		}
-	}
-
-	return nil, fmt.Errorf("no host found for repository '%s'", repositoryName)
 }
 
 // setInputs sets inputs passed to Run().

--- a/pkg/command/run_test.go
+++ b/pkg/command/run_test.go
@@ -60,6 +60,14 @@ func (m *mockHost) ListRepositoriesWithOpenPullRequests(result chan []host.Repos
 	errChan <- nil
 }
 
+func (m *mockHost) AuthenticatedUser() (*host.UserInfo, error) {
+	return nil, nil
+}
+
+func (m *mockHost) Name() string {
+	return "mock"
+}
+
 func createTestCache(taskFilePath string) string {
 	f, err := os.Open(taskFilePath)
 	if err != nil {

--- a/pkg/command/try.go
+++ b/pkg/command/try.go
@@ -64,24 +64,12 @@ func (r *TryRunner) Run() error {
 		return fmt.Errorf("required flag `--task-file` is not set")
 	}
 
-	var repository host.Repository
-	for _, host := range r.Hosts {
-		var err error
-		repository, err = host.CreateFromName(r.RepositoryName)
-		if err != nil {
-			return fmt.Errorf("create repository: %w", err)
-		}
-
-		if repository != nil {
-			break
-		}
+	repository, err := host.NewRepositoryFromName(r.Hosts, r.RepositoryName)
+	if err != nil {
+		return err
 	}
 
-	if repository == nil {
-		return fmt.Errorf("no host supports the repository")
-	}
-
-	err := r.Registry.ReadAll([]string{r.TaskFile})
+	err = r.Registry.ReadAll([]string{r.TaskFile})
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,7 +26,7 @@ var (
 	//go:embed config.schema.json
 	schemaRaw string
 	// ErrNoToken informs the user that at least one token is required.
-	ErrNoToken = errors.New("no GitHub token or GitLab token configured")
+	ErrNoToken = errors.New("no githubToken or gitlabToken configured - https://saturn-bot.readthedocs.io/en/latest/configuration/")
 )
 
 func (c Configuration) GitUserEmail() string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -49,7 +49,7 @@ func TestReadConfig(t *testing.T) {
 				GithubToken: nil,
 				GitlabToken: nil,
 			},
-			readErr: "no GitHub token or GitLab token configured",
+			readErr: "no githubToken or gitlabToken configured - https://saturn-bot.readthedocs.io/en/latest/configuration/",
 		},
 	}
 

--- a/pkg/filter/hostmock_test.go
+++ b/pkg/filter/hostmock_test.go
@@ -465,6 +465,21 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
 }
 
+// AuthenticatedUser mocks base method.
+func (m *MockHost) AuthenticatedUser() (*host.UserInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthenticatedUser")
+	ret0, _ := ret[0].(*host.UserInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthenticatedUser indicates an expected call of AuthenticatedUser.
+func (mr *MockHostMockRecorder) AuthenticatedUser() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticatedUser", reflect.TypeOf((*MockHost)(nil).AuthenticatedUser))
+}
+
 // CreateFromName mocks base method.
 func (m *MockHost) CreateFromName(name string) (host.Repository, error) {
 	m.ctrl.T.Helper()
@@ -502,6 +517,20 @@ func (m *MockHost) ListRepositoriesWithOpenPullRequests(result chan []host.Repos
 func (mr *MockHostMockRecorder) ListRepositoriesWithOpenPullRequests(result, errChan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositoriesWithOpenPullRequests", reflect.TypeOf((*MockHost)(nil).ListRepositoriesWithOpenPullRequests), result, errChan)
+}
+
+// Name mocks base method.
+func (m *MockHost) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHostMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHost)(nil).Name))
 }
 
 // MockHostDetail is a mock of HostDetail interface.

--- a/pkg/git/hostmock_test.go
+++ b/pkg/git/hostmock_test.go
@@ -465,6 +465,21 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
 }
 
+// AuthenticatedUser mocks base method.
+func (m *MockHost) AuthenticatedUser() (*host.UserInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthenticatedUser")
+	ret0, _ := ret[0].(*host.UserInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthenticatedUser indicates an expected call of AuthenticatedUser.
+func (mr *MockHostMockRecorder) AuthenticatedUser() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticatedUser", reflect.TypeOf((*MockHost)(nil).AuthenticatedUser))
+}
+
 // CreateFromName mocks base method.
 func (m *MockHost) CreateFromName(name string) (host.Repository, error) {
 	m.ctrl.T.Helper()
@@ -502,6 +517,20 @@ func (m *MockHost) ListRepositoriesWithOpenPullRequests(result chan []host.Repos
 func (mr *MockHostMockRecorder) ListRepositoriesWithOpenPullRequests(result, errChan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositoriesWithOpenPullRequests", reflect.TypeOf((*MockHost)(nil).ListRepositoriesWithOpenPullRequests), result, errChan)
+}
+
+// Name mocks base method.
+func (m *MockHost) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHostMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHost)(nil).Name))
 }
 
 // MockHostDetail is a mock of HostDetail interface.

--- a/pkg/plugin/hostmock_test.go
+++ b/pkg/plugin/hostmock_test.go
@@ -465,6 +465,21 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
 }
 
+// AuthenticatedUser mocks base method.
+func (m *MockHost) AuthenticatedUser() (*host.UserInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthenticatedUser")
+	ret0, _ := ret[0].(*host.UserInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthenticatedUser indicates an expected call of AuthenticatedUser.
+func (mr *MockHostMockRecorder) AuthenticatedUser() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticatedUser", reflect.TypeOf((*MockHost)(nil).AuthenticatedUser))
+}
+
 // CreateFromName mocks base method.
 func (m *MockHost) CreateFromName(name string) (host.Repository, error) {
 	m.ctrl.T.Helper()
@@ -502,6 +517,20 @@ func (m *MockHost) ListRepositoriesWithOpenPullRequests(result chan []host.Repos
 func (mr *MockHostMockRecorder) ListRepositoriesWithOpenPullRequests(result, errChan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositoriesWithOpenPullRequests", reflect.TypeOf((*MockHost)(nil).ListRepositoriesWithOpenPullRequests), result, errChan)
+}
+
+// Name mocks base method.
+func (m *MockHost) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHostMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHost)(nil).Name))
 }
 
 // MockHostDetail is a mock of HostDetail interface.

--- a/pkg/processor/hostmock_test.go
+++ b/pkg/processor/hostmock_test.go
@@ -465,6 +465,21 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
 }
 
+// AuthenticatedUser mocks base method.
+func (m *MockHost) AuthenticatedUser() (*host.UserInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthenticatedUser")
+	ret0, _ := ret[0].(*host.UserInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthenticatedUser indicates an expected call of AuthenticatedUser.
+func (mr *MockHostMockRecorder) AuthenticatedUser() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticatedUser", reflect.TypeOf((*MockHost)(nil).AuthenticatedUser))
+}
+
 // CreateFromName mocks base method.
 func (m *MockHost) CreateFromName(name string) (host.Repository, error) {
 	m.ctrl.T.Helper()
@@ -502,6 +517,20 @@ func (m *MockHost) ListRepositoriesWithOpenPullRequests(result chan []host.Repos
 func (mr *MockHostMockRecorder) ListRepositoriesWithOpenPullRequests(result, errChan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositoriesWithOpenPullRequests", reflect.TypeOf((*MockHost)(nil).ListRepositoriesWithOpenPullRequests), result, errChan)
+}
+
+// Name mocks base method.
+func (m *MockHost) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHostMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHost)(nil).Name))
 }
 
 // MockHostDetail is a mock of HostDetail interface.

--- a/pkg/task/hostmock_test.go
+++ b/pkg/task/hostmock_test.go
@@ -465,6 +465,21 @@ func (m *MockHost) EXPECT() *MockHostMockRecorder {
 	return m.recorder
 }
 
+// AuthenticatedUser mocks base method.
+func (m *MockHost) AuthenticatedUser() (*host.UserInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthenticatedUser")
+	ret0, _ := ret[0].(*host.UserInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthenticatedUser indicates an expected call of AuthenticatedUser.
+func (mr *MockHostMockRecorder) AuthenticatedUser() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticatedUser", reflect.TypeOf((*MockHost)(nil).AuthenticatedUser))
+}
+
 // CreateFromName mocks base method.
 func (m *MockHost) CreateFromName(name string) (host.Repository, error) {
 	m.ctrl.T.Helper()
@@ -502,6 +517,20 @@ func (m *MockHost) ListRepositoriesWithOpenPullRequests(result chan []host.Repos
 func (mr *MockHostMockRecorder) ListRepositoriesWithOpenPullRequests(result, errChan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositoriesWithOpenPullRequests", reflect.TypeOf((*MockHost)(nil).ListRepositoriesWithOpenPullRequests), result, errChan)
+}
+
+// Name mocks base method.
+func (m *MockHost) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockHostMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockHost)(nil).Name))
 }
 
 // MockHostDetail is a mock of HostDetail interface.


### PR DESCRIPTION
- Introduce function `host.NewRepositoryFromName` as a single entrypoint.
- Improve error messages.