### PR TITLE
fix(host): Only return merge requests in state "opened" from GitLab API

### DIFF
--- a/pkg/host/gitlab.go
+++ b/pkg/host/gitlab.go
@@ -665,6 +665,7 @@ func (g *GitLabHost) ListRepositoriesWithOpenPullRequests(result chan []Reposito
 			Page:    1,
 			PerPage: 20,
 		},
+		State: gitlab.Ptr("opened"),
 	}
 	visitedProjectsIDs := map[int]struct{}{}
 	for {

--- a/pkg/host/gitlab_test.go
+++ b/pkg/host/gitlab_test.go
@@ -890,6 +890,7 @@ func TestGitLabHost_ListRepositoriesWithOpenPullRequests(t *testing.T) {
 		Get("/api/v4/merge_requests").
 		MatchParam("author_id", "4321").
 		MatchParam("per_page", "20").
+		MatchParam("state", "opened").
 		Reply(200).
 		JSON([]*gitlab.MergeRequest{
 			{IID: 1, ProjectID: 123},
@@ -942,6 +943,7 @@ func TestGitLabHost_ListRepositoriesWithOpenPullRequests(t *testing.T) {
 	require.IsType(t, &RepositoryProxy{}, result[0])
 	require.Equal(t, "gitlab.local/unittest/second", result[1].FullName())
 	require.IsType(t, &RepositoryProxy{}, result[1])
+	require.True(t, gock.IsDone())
 }
 
 func setupClient() *gitlab.Client {


### PR DESCRIPTION
Implementation of `ListRepositoriesWithOpenPullRequests` can return repositories for which a merge request is currently open.

Before this change, the code queried for merge requests all states, leading to more API calls than necessary.