### PR TITLE
feat(server): Display link to pull request in UI

### DIFF
--- a/pkg/command/processormock_test.go
+++ b/pkg/command/processormock_test.go
@@ -46,12 +46,13 @@ func (m *MockRepositoryTaskProcessor) EXPECT() *MockRepositoryTaskProcessorMockR
 }
 
 // Process mocks base method.
-func (m *MockRepositoryTaskProcessor) Process(ctx context.Context, dryRun bool, repo host.Repository, task *task.Task, doFilter bool) (processor.Result, error) {
+func (m *MockRepositoryTaskProcessor) Process(ctx context.Context, dryRun bool, repo host.Repository, task *task.Task, doFilter bool) (processor.Result, *host.PullRequest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Process", ctx, dryRun, repo, task, doFilter)
 	ret0, _ := ret[0].(processor.Result)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(*host.PullRequest)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Process indicates an expected call of Process.

--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -29,6 +29,7 @@ var (
 
 type RunResult struct {
 	Error          error
+	PullRequest    *host.PullRequest
 	RepositoryName string
 	Result         processor.Result
 	TaskName       string
@@ -114,7 +115,7 @@ func (r *Run) Run(repositoryNames, taskFiles []string, inputs map[string]string)
 							log.FieldTask(t.Name),
 						))
 					ctx = sContext.WithLog(ctx, logger)
-					result.Result, result.Error = r.Processor.Process(ctx, r.DryRun, repo, t, doFilter)
+					result.Result, result.PullRequest, result.Error = r.Processor.Process(ctx, r.DryRun, repo, t, doFilter)
 					if result.Error == nil {
 						metrics.RunTaskSuccess.WithLabelValues(t.Name).Set(1)
 					} else {

--- a/pkg/command/run_test.go
+++ b/pkg/command/run_test.go
@@ -182,10 +182,10 @@ func TestExecuteRunner_Run(t *testing.T) {
 	var anyTask *task.Task = &task.Task{}
 	procMock.EXPECT().
 		Process(gomock.AssignableToTypeOf(ctx), false, repo, gomock.AssignableToTypeOf(anyTask), true).
-		Return(processor.ResultNoChanges, nil)
+		Return(processor.ResultNoChanges, nil, nil)
 	procMock.EXPECT().
 		Process(gomock.AssignableToTypeOf(ctx), false, repoWithPr, gomock.AssignableToTypeOf(anyTask), true).
-		Return(processor.ResultNoChanges, nil)
+		Return(processor.ResultNoChanges, nil, nil)
 
 	defer gock.Off()
 	gock.New("http://pgw.local").
@@ -234,7 +234,7 @@ func TestExecuteRunner_Run_DryRun(t *testing.T) {
 	var anyTask *task.Task = &task.Task{}
 	procMock.EXPECT().
 		Process(gomock.AssignableToTypeOf(ctx), true, repo, gomock.AssignableToTypeOf(anyTask), true).
-		Return(processor.ResultNoChanges, nil)
+		Return(processor.ResultNoChanges, nil, nil)
 	taskRegistry := task.NewRegistry(runTestOpts)
 
 	runner := &command.Run{
@@ -275,7 +275,7 @@ func TestExecuteRunner_Run_RepositoriesCLI(t *testing.T) {
 	var anyTask *task.Task = &task.Task{}
 	procMock.EXPECT().
 		Process(gomock.AssignableToTypeOf(ctx), false, repo, gomock.AssignableToTypeOf(anyTask), false).
-		Return(processor.ResultNoChanges, nil)
+		Return(processor.ResultNoChanges, nil, nil)
 	taskRegistry := task.NewRegistry(runTestOpts)
 
 	runner := &command.Run{
@@ -336,7 +336,7 @@ func TestExecuteRunner_Run_Inputs(t *testing.T) {
 
 	procMock.EXPECT().
 		Process(gomock.AssignableToTypeOf(ctx), false, repo, gomock.Cond(isTask), false).
-		Return(processor.ResultNoChanges, nil)
+		Return(processor.ResultNoChanges, nil, nil)
 
 	runner := &command.Run{
 		Cache:        cache,

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -60,6 +60,7 @@ func TestProcessor_Process_CreatePullRequestLocalChanges(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	repo := setupRepoMock(ctrl)
 	repo.EXPECT().FindPullRequest("saturn-bot--unittest").Return(nil, nil)
+	repo.EXPECT().PullRequest(nil).Return(nil).AnyTimes()
 	repo.EXPECT().IsPullRequestClosed(nil).Return(false).AnyTimes()
 	repo.EXPECT().IsPullRequestMerged(nil).Return(false).AnyTimes()
 	repo.EXPECT().GetPullRequestBody(nil).Return("").AnyTimes()
@@ -78,7 +79,7 @@ func TestProcessor_Process_CreatePullRequestLocalChanges(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrCreated, result)
@@ -94,6 +95,7 @@ func TestProcessor_Process_CreatePullRequestRemoteChanges(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	repo := setupRepoMock(ctrl)
 	repo.EXPECT().FindPullRequest("saturn-bot--unittest").Return(nil, nil)
+	repo.EXPECT().PullRequest(nil).Return(nil).AnyTimes()
 	repo.EXPECT().IsPullRequestClosed(nil).Return(false).AnyTimes()
 	repo.EXPECT().IsPullRequestMerged(nil).Return(false).AnyTimes()
 	repo.EXPECT().GetPullRequestBody(nil).Return("").AnyTimes()
@@ -111,7 +113,7 @@ func TestProcessor_Process_CreatePullRequestRemoteChanges(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrCreated, result)
@@ -128,6 +130,7 @@ func TestProcessor_Process_CreatePullRequestPreviouslyClosed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	repo := setupRepoMock(ctrl)
 	repo.EXPECT().FindPullRequest("saturn-bot--unittest").Return(prID, nil)
+	repo.EXPECT().PullRequest(prID).Return(nil).AnyTimes()
 	repo.EXPECT().IsPullRequestClosed(prID).Return(true).AnyTimes()
 	repo.EXPECT().IsPullRequestMerged(prID).Return(false).AnyTimes()
 	repo.EXPECT().GetPullRequestBody(nil).Return("").AnyTimes()
@@ -144,7 +147,7 @@ func TestProcessor_Process_CreatePullRequestPreviouslyClosed(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrCreated, result)
@@ -155,6 +158,7 @@ func TestProcessor_Process_PullRequestClosedAndMergeOnceActive(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	repo := setupRepoMock(ctrl)
 	repo.EXPECT().FindPullRequest("saturn-bot--unittest").Return(prID, nil)
+	repo.EXPECT().PullRequest(prID).Return(nil).AnyTimes()
 	repo.EXPECT().IsPullRequestClosed(prID).Return(true)
 	gitc := NewMockGitClient(ctrl)
 	gitc.EXPECT().Prepare(repo, false).Return("/tmp", nil)
@@ -162,7 +166,7 @@ func TestProcessor_Process_PullRequestClosedAndMergeOnceActive(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrClosedBefore, result)
@@ -173,6 +177,7 @@ func TestProcessor_Process_PullRequestMergedAndMergeOnceActive(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	repo := setupRepoMock(ctrl)
 	repo.EXPECT().FindPullRequest("saturn-bot--unittest").Return(prID, nil)
+	repo.EXPECT().PullRequest(prID).Return(nil).AnyTimes()
 	repo.EXPECT().IsPullRequestClosed(prID).Return(false)
 	repo.EXPECT().IsPullRequestMerged(prID).Return(true)
 	gitc := NewMockGitClient(ctrl)
@@ -181,7 +186,7 @@ func TestProcessor_Process_PullRequestMergedAndMergeOnceActive(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrMergedBefore, result)
@@ -192,6 +197,7 @@ func TestProcessor_Process_CreateOnly(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	repo := setupRepoMock(ctrl)
 	repo.EXPECT().FindPullRequest("saturn-bot--unittest").Return(prID, nil)
+	repo.EXPECT().PullRequest(prID).Return(nil).AnyTimes()
 	repo.EXPECT().IsPullRequestClosed(prID).Return(false)
 	repo.EXPECT().IsPullRequestMerged(prID).Return(false)
 	gitc := NewMockGitClient(ctrl)
@@ -200,7 +206,7 @@ func TestProcessor_Process_CreateOnly(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrOpen, result)
@@ -236,7 +242,7 @@ func TestProcessor_Process_ClosePullRequestIfChangesExistInBaseBranch(t *testing
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrClosed, result)
@@ -273,7 +279,7 @@ func TestProcessor_Process_MergePullRequest(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrMerged, result)
@@ -307,7 +313,7 @@ func TestProcessor_Process_MergePullRequest_FailedMergeChecks(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultChecksFailed, result)
@@ -346,7 +352,7 @@ func TestProcessor_Process_MergePullRequest_AutoMergeAfter(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultAutoMergeTooEarly, result)
@@ -385,7 +391,7 @@ func TestProcessor_Process_MergePullRequest_MergeConflict(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultConflict, result)
@@ -431,7 +437,7 @@ func TestProcessor_Process_UpdatePullRequest(t *testing.T) {
 		Title: "saturn-bot: task unittest",
 	}
 	repo.EXPECT().UpdatePullRequest(prData, prID).Return(nil)
-	repo.EXPECT().PullRequest(prID).Return(nil)
+	repo.EXPECT().PullRequest(prID).Return(nil).AnyTimes()
 	gitc := NewMockGitClient(ctrl)
 	gitc.EXPECT().Prepare(repo, false).Return(tempDir, nil)
 	gitc.EXPECT().UpdateTaskBranch("saturn-bot--unittest", false, repo)
@@ -460,7 +466,7 @@ func TestProcessor_Process_UpdatePullRequest(t *testing.T) {
 	})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(ctx, false, repo, tw, true)
+	result, _, err := p.Process(ctx, false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrOpen, result)
@@ -477,6 +483,7 @@ func TestProcessor_Process_NoChanges(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	repo := setupRepoMock(ctrl)
 	repo.EXPECT().FindPullRequest("saturn-bot--unittest").Return(prID, nil)
+	repo.EXPECT().PullRequest(prID).Return(nil).AnyTimes()
 	repo.EXPECT().IsPullRequestClosed(prID).Return(false).AnyTimes()
 	repo.EXPECT().IsPullRequestMerged(prID).Return(false).AnyTimes()
 	repo.EXPECT().GetPullRequestBody(prID).Return("")
@@ -492,7 +499,7 @@ func TestProcessor_Process_NoChanges(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultNoChanges, result)
@@ -544,7 +551,7 @@ The commit(s) that modified the pull request:
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultBranchModified, result)
@@ -572,7 +579,7 @@ func TestProcessor_Process_ForceRebaseByUser(t *testing.T) {
 		Return([]host.PullRequestComment{prComment}, nil)
 	repo.EXPECT().DeletePullRequestComment(prComment, prID).Return(nil)
 	repo.EXPECT().UpdatePullRequest(gomock.AssignableToTypeOf(host.PullRequestData{}), prID).Return(nil)
-	repo.EXPECT().PullRequest(prID).Return(nil)
+	repo.EXPECT().PullRequest(prID).Return(nil).AnyTimes()
 	gitc := NewMockGitClient(ctrl)
 	gitc.EXPECT().Prepare(repo, false).Return(tempDir, nil)
 	gitc.EXPECT().UpdateTaskBranch("saturn-bot--unittest", true, repo).Return(false, nil)
@@ -584,7 +591,7 @@ func TestProcessor_Process_ForceRebaseByUser(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrOpen, result)
@@ -598,7 +605,7 @@ func TestProcessor_Process_ChangeLimit(t *testing.T) {
 	tw.IncChangeLimitCount()
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultSkip, result)
@@ -612,7 +619,7 @@ func TestProcessor_Process_MaxOpenPRs(t *testing.T) {
 	tw.IncOpenPRsCount()
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultSkip, result)
@@ -626,7 +633,7 @@ func TestProcessor_Process_FilterNotMatching(t *testing.T) {
 	tw.AddFilters(&falseFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultNoMatch, result)
@@ -639,7 +646,7 @@ func TestProcessor_Process_NoFilters(t *testing.T) {
 	tw := &task.Task{Task: schema.Task{Name: "unittest"}}
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultNoMatch, result)
@@ -663,7 +670,7 @@ func TestProcessor_Process_AutoCloseAfter_Close(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrClosed, result)
@@ -692,7 +699,7 @@ func TestProcessor_Process_AutoCloseAfter_NotTimeYet(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultPrOpen, result)
@@ -723,7 +730,7 @@ func TestProcessor_Process_EmptyRepository(t *testing.T) {
 	tw.AddFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, err := p.Process(context.Background(), false, repo, tw, true)
+	result, _, err := p.Process(context.Background(), false, repo, tw, true)
 
 	require.NoError(t, err)
 	assert.Equal(t, processor.ResultNoMatch, result)

--- a/pkg/server/api/openapi/openapi.yaml
+++ b/pkg/server/api/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: saturn-bot server API
-  version: 1.0.0
+  version: 0.1.0
 paths:
   /api/v1/runs:
     post:

--- a/pkg/server/api/openapi/openapi.yaml
+++ b/pkg/server/api/openapi/openapi.yaml
@@ -311,6 +311,9 @@ components:
         error:
           description: Error encountered during the run, if any.
           type: string
+        pullRequestUrl:
+          description: URL of the pull request for humans to view.
+          type: string
         repositoryName:
           description: Name of the repository.
           type: string

--- a/pkg/server/api/openapi/server.gen.go
+++ b/pkg/server/api/openapi/server.gen.go
@@ -156,6 +156,9 @@ type ReportWorkV1TaskResult struct {
 	// Error Error encountered during the run, if any.
 	Error *string `json:"error,omitempty"`
 
+	// PullRequestUrl URL of the pull request for humans to view.
+	PullRequestUrl *string `json:"pullRequestUrl,omitempty"`
+
 	// RepositoryName Name of the repository.
 	RepositoryName string `json:"repositoryName"`
 

--- a/pkg/server/api/task.go
+++ b/pkg/server/api/task.go
@@ -93,5 +93,9 @@ func mapTaskResultFromDbToApi(db db.TaskResult) openapi.TaskResultV1 {
 		api.Error = db.Error
 	}
 
+	if db.PullRequestUrl != nil {
+		api.PullRequestUrl = db.PullRequestUrl
+	}
+
 	return api
 }

--- a/pkg/server/db/migrations/20241227163206_task_results-add-column-pull_request_url.down.sql
+++ b/pkg/server/db/migrations/20241227163206_task_results-add-column-pull_request_url.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `task_results` DROP COLUMN `pull_request_url`;

--- a/pkg/server/db/migrations/20241227163206_task_results-add-column-pull_request_url.up.sql
+++ b/pkg/server/db/migrations/20241227163206_task_results-add-column-pull_request_url.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `task_results` ADD COLUMN `pull_request_url` TEXT;

--- a/pkg/server/db/model.go
+++ b/pkg/server/db/model.go
@@ -56,6 +56,7 @@ type TaskResult struct {
 	CreatedAt      time.Time
 	Error          *string
 	ID             uint `gorm:"primarykey"`
+	PullRequestUrl *string
 	RepositoryName string
 	Result         int
 	Status         TaskResultStatus

--- a/pkg/server/integration/taskresult_test.go
+++ b/pkg/server/integration/taskresult_test.go
@@ -36,10 +36,25 @@ func Test_API_ListTaskResultsV1(t *testing.T) {
 							Name: defaultTask.Name,
 						},
 						TaskResults: []openapi.ReportWorkV1TaskResult{
-							{RepositoryName: "git.local/unittest/one", Result: int(processor.ResultPrOpen)},
-							{RepositoryName: "git.local/unittest/two", Result: int(processor.ResultPrClosed)},
-							{RepositoryName: "git.local/unittest/three", Result: int(processor.ResultPrMerged)},
-							{RepositoryName: "git.local/unittest/four", Result: int(processor.ResultUnknown), Error: ptr.To("error")},
+							{
+								PullRequestUrl: ptr.To("https://git.local/unittest/one/pr/1"),
+								RepositoryName: "git.local/unittest/one",
+								Result:         int(processor.ResultPrOpen),
+							},
+							{
+								PullRequestUrl: ptr.To("https://git.local/unittest/two/pr/1"),
+								RepositoryName: "git.local/unittest/two",
+								Result:         int(processor.ResultPrClosed),
+							},
+							{
+								PullRequestUrl: ptr.To("https://git.local/unittest/three/pr/1"),
+								RepositoryName: "git.local/unittest/three",
+								Result:         int(processor.ResultPrMerged),
+							},
+							{
+								RepositoryName: "git.local/unittest/four",
+								Result:         int(processor.ResultUnknown), Error: ptr.To("error"),
+							},
 						},
 					},
 					statusCode: http.StatusCreated,
@@ -55,10 +70,30 @@ func Test_API_ListTaskResultsV1(t *testing.T) {
 					responseBody: openapi.ListTaskResultsV1Response{
 						Page: openapi.Page{CurrentPage: 1, ItemsPerPage: 20, TotalItems: 4, TotalPages: 1},
 						TaskResults: []openapi.TaskResultV1{
-							{RepositoryName: "git.local/unittest/four", RunId: 1, Error: ptr.To("error"), Status: openapi.TaskResultStatusV1Error},
-							{RepositoryName: "git.local/unittest/three", RunId: 1, Status: openapi.TaskResultStatusV1Merged},
-							{RepositoryName: "git.local/unittest/two", RunId: 1, Status: openapi.TaskResultStatusV1Closed},
-							{RepositoryName: "git.local/unittest/one", RunId: 1, Status: openapi.TaskResultStatusV1Open},
+							{
+								RepositoryName: "git.local/unittest/four",
+								RunId:          1,
+								Error:          ptr.To("error"),
+								Status:         openapi.TaskResultStatusV1Error,
+							},
+							{
+								PullRequestUrl: ptr.To("https://git.local/unittest/three/pr/1"),
+								RepositoryName: "git.local/unittest/three",
+								RunId:          1,
+								Status:         openapi.TaskResultStatusV1Merged,
+							},
+							{
+								PullRequestUrl: ptr.To("https://git.local/unittest/two/pr/1"),
+								RepositoryName: "git.local/unittest/two",
+								RunId:          1,
+								Status:         openapi.TaskResultStatusV1Closed,
+							},
+							{
+								PullRequestUrl: ptr.To("https://git.local/unittest/one/pr/1"),
+								RepositoryName: "git.local/unittest/one",
+								RunId:          1,
+								Status:         openapi.TaskResultStatusV1Open,
+							},
 						},
 					},
 				},
@@ -71,7 +106,12 @@ func Test_API_ListTaskResultsV1(t *testing.T) {
 					responseBody: openapi.ListTaskResultsV1Response{
 						Page: openapi.Page{CurrentPage: 1, ItemsPerPage: 20, TotalItems: 1, TotalPages: 1},
 						TaskResults: []openapi.TaskResultV1{
-							{RepositoryName: "git.local/unittest/three", RunId: 1, Status: openapi.TaskResultStatusV1Merged},
+							{
+								PullRequestUrl: ptr.To("https://git.local/unittest/three/pr/1"),
+								RepositoryName: "git.local/unittest/three",
+								RunId:          1,
+								Status:         openapi.TaskResultStatusV1Merged,
+							},
 						},
 					},
 				},

--- a/pkg/server/service/workerservice.go
+++ b/pkg/server/service/workerservice.go
@@ -231,6 +231,10 @@ func (ws *WorkerService) ReportRun(req openapi.ReportWorkV1Request) error {
 				result.Error = taskResult.Error
 			}
 
+			if taskResult.PullRequestUrl != nil {
+				result.PullRequestUrl = taskResult.PullRequestUrl
+			}
+
 			if err := tx.Save(&result).Error; err != nil {
 				return err
 			}

--- a/pkg/server/ui/templates/task-results-table.html
+++ b/pkg/server/ui/templates/task-results-table.html
@@ -43,7 +43,11 @@
           <td>
             <a href="https://{{.RepositoryName}}">{{.RepositoryName}}</a>
           </td>
-          <td></td>
+          <td>
+            {{if .PullRequestUrl}}
+            <a href="{{.PullRequestUrl}}">{{.PullRequestUrl}}</a>
+            {{end}}
+          </td>
           <td>
             <span class="tag {{.Status | taskResultStatusToCssClass}}">{{.Status}}</span>
           </td>

--- a/pkg/worker/client/openapi.gen.go
+++ b/pkg/worker/client/openapi.gen.go
@@ -158,6 +158,9 @@ type ReportWorkV1TaskResult struct {
 	// Error Error encountered during the run, if any.
 	Error *string `json:"error,omitempty"`
 
+	// PullRequestUrl URL of the pull request for humans to view.
+	PullRequestUrl *string `json:"pullRequestUrl,omitempty"`
+
 	// RepositoryName Name of the repository.
 	RepositoryName string `json:"repositoryName"`
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -260,6 +260,10 @@ func mapRunResultsToTaskResults(runResults []command.RunResult) []client.ReportW
 			result.Error = ptr.To(rr.Error.Error())
 		}
 
+		if rr.PullRequest != nil {
+			result.PullRequestUrl = ptr.To(rr.PullRequest.WebURL)
+		}
+
 		results = append(results, result)
 	}
 


### PR DESCRIPTION
- Accept link to pull request via the API and store it in the database.
- Make `processor.Process()` return data on the pull request.
- Include the pull request url in report data sent from worker to server.
- Display link in the UI.