### PR TITLE
refactor: Update default branch of a repository only once

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -72,9 +72,9 @@ func (p *Processor) Process(dryRun bool, repo host.Repository, tasks []*task.Tas
 		}
 
 		taskLogger := logger.With(log.FieldTask(t.Name))
-		ctx = sbcontext.WithLog(ctx, taskLogger)
-		ctx = sbcontext.WithRunData(ctx, t.InputData())
-		match, preCloneResult, err := p.filterPreClone(ctx, t)
+		taskCtx := sbcontext.WithLog(ctx, taskLogger)
+		taskCtx = sbcontext.WithRunData(taskCtx, t.InputData())
+		match, preCloneResult, err := p.filterPreClone(taskCtx, t)
 		result := ProcessResult{
 			Task: t,
 		}
@@ -125,9 +125,9 @@ func (p *Processor) Process(dryRun bool, repo host.Repository, tasks []*task.Tas
 			WithOptions(zap.Fields(
 				log.FieldTask(t.Name),
 			))
-		ctx = sbcontext.WithLog(ctx, taskLogger)
-		ctx = sbcontext.WithRunData(ctx, t.InputData())
-		resultId, pr, err := p.processPostClone(ctx, repo, t, doFilter, dryRun)
+		taskCtx := sbcontext.WithLog(ctx, taskLogger)
+		taskCtx = sbcontext.WithRunData(taskCtx, t.InputData())
+		resultId, pr, err := p.processPostClone(taskCtx, repo, t, doFilter, dryRun)
 		result := ProcessResult{
 			PullRequest: pr,
 			Result:      resultId,

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -54,7 +54,6 @@ type Processor struct {
 
 type RepositoryTaskProcessor interface {
 	Process(dryRun bool, repo host.Repository, tasks []*task.Task, doFilter bool) []ProcessResult
-	// ProcessAll(dryRun bool, repo host.Repository, tasks []*task.Task, doFilter bool) []ProcessResult
 }
 
 func (p *Processor) Process(dryRun bool, repo host.Repository, tasks []*task.Task, doFilter bool) []ProcessResult {
@@ -219,102 +218,6 @@ func (p *Processor) processPostClone(ctx context.Context, repo host.Repository, 
 
 	return result, prDetail, nil
 }
-
-// func (p *Processor) Process(
-// 	ctx context.Context,
-// 	dryRun bool,
-// 	repo host.Repository,
-// 	task *task.Task,
-// 	doFilter bool,
-// ) (Result, *host.PullRequest, error) {
-// 	ctx = sbcontext.WithRunData(ctx, task.InputData())
-// 	logger := sbcontext.Log(ctx)
-// 	logger.Debug("Processing repository")
-// 	if task.HasReachMaxOpenPRs() {
-// 		logger.Debug("Skipping task because Max Open PRs have been reached")
-// 		return ResultSkip, nil, nil
-// 	}
-
-// 	if task.HasReachedChangeLimit() {
-// 		logger.Debug("Skipping task because Change Limit have been reached")
-// 		return ResultSkip, nil, nil
-// 	}
-
-// 	if !task.HasFilters() {
-// 		// A task without filters is considered not matching.
-// 		// Avoids accidentally applying a task to all repositories
-// 		// because no filters are set.
-// 		return ResultNoMatch, nil, nil
-// 	}
-
-// 	ctx = context.WithValue(ctx, sbcontext.RepositoryKey{}, repo)
-
-// 	if doFilter {
-// 		match, err := matchTaskToRepository(ctx, task.FiltersPreClone(), logger)
-// 		if err != nil {
-// 			return ResultUnknown, nil, err
-// 		}
-
-// 		if !match {
-// 			return ResultNoMatch, nil, nil
-// 		}
-// 	}
-
-// 	lck := &locker{}
-// 	err := lck.lock(p.DataDir, repo)
-// 	if err != nil {
-// 		return ResultUnknown, nil, fmt.Errorf("lock of repository '%s' failed: %w", repo.FullName(), err)
-// 	}
-
-// 	defer func() {
-// 		err := lck.unlock()
-// 		if err != nil {
-// 			logger.Error("Failed to unlock repository")
-// 		}
-// 	}()
-
-// 	workDir, err := p.Git.Prepare(repo, false)
-// 	if err != nil {
-// 		// A error during the preparation of the git repository is the best indicator that
-// 		// the repository has been deleted.
-// 		// Log a warning, clean up and consider the repository as "not matching".
-// 		logger.Warnf("Failed to clone or pull repository - cleaning up the repository")
-// 		err := p.Git.Cleanup(repo)
-// 		if err != nil {
-// 			return ResultUnknown, nil, fmt.Errorf("cleanup of git repository clone: %w", err)
-// 		}
-
-// 		return ResultNoMatch, nil, nil
-// 	}
-
-// 	ctx = context.WithValue(ctx, sbcontext.CheckoutPath{}, workDir)
-// 	if doFilter {
-// 		match, err := matchTaskToRepository(ctx, task.FiltersPostClone(), logger)
-// 		if err != nil {
-// 			return ResultUnknown, nil, err
-// 		}
-
-// 		if !match {
-// 			return ResultNoMatch, nil, nil
-// 		}
-// 	}
-
-// 	logger.Info("Task matches repository")
-// 	result, prDetail, err := applyTaskToRepository(ctx, dryRun, p.Git, logger, repo, task, workDir)
-// 	if err != nil {
-// 		return ResultUnknown, prDetail, fmt.Errorf("task failed: %w", err)
-// 	}
-
-// 	if result == ResultPrCreated || result == ResultPrOpen {
-// 		task.IncOpenPRsCount()
-// 	}
-
-// 	if result == ResultPrCreated || result == ResultPrMerged {
-// 		task.IncChangeLimitCount()
-// 	}
-
-// 	return result, prDetail, nil
-// }
 
 func matchTaskToRepository(ctx context.Context, filters []filter.Filter, logger *zap.SugaredLogger) (bool, error) {
 	for _, filter := range filters {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -190,7 +190,6 @@ func (p *Processor) processPostClone(ctx context.Context, repo host.Repository, 
 		}
 	}()
 
-	checkoutDir := ctx.Value(sbcontext.CheckoutPath{}).(string)
 	if doFilter {
 		match, err := matchTaskToRepository(ctx, task.FiltersPostClone(), logger)
 		if err != nil {
@@ -203,6 +202,7 @@ func (p *Processor) processPostClone(ctx context.Context, repo host.Repository, 
 	}
 
 	logger.Info("Task matches repository")
+	checkoutDir := ctx.Value(sbcontext.CheckoutPath{}).(string)
 	result, prDetail, err := applyTaskToRepository(ctx, dryRun, p.Git, logger, repo, task, checkoutDir)
 	if err != nil {
 		return ResultUnknown, prDetail, fmt.Errorf("task failed: %w", err)

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -85,11 +85,16 @@ func TestProcessor_Process_CreatePullRequestLocalChanges(t *testing.T) {
 	tw.AddPreCloneFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
-	result, pr, err := p.Process(context.Background(), false, repo, tw, true)
+	// result, pr, err := p.Process(context.Background(), false, repo, tw, true)
+	results := p.ProcessAll(repo, []*task.Task{tw}, true, false)
 
-	require.NoError(t, err)
-	assert.Equal(t, processor.ResultPrCreated, result)
-	assert.Equal(t, prCreate, pr)
+	// require.NoError(t, err)
+	// assert.Equal(t, processor.ResultPrCreated, result)
+	// assert.Equal(t, prCreate, pr)
+	assert.Len(t, results, 1)
+	assert.Equal(t, processor.ResultPrCreated, results[0].Result)
+	assert.Equal(t, prCreate, results[0].PullRequest)
+	assert.NoError(t, results[0].Error)
 }
 
 func TestProcessor_Process_CreatePullRequestRemoteChanges(t *testing.T) {

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -80,7 +80,7 @@ func TestProcessor_Process_CreatePullRequestLocalChanges(t *testing.T) {
 	gitc.EXPECT().HasRemoteChanges("main").Return(false, nil)
 	gitc.EXPECT().HasRemoteChanges("saturn-bot--unittest").Return(true, nil)
 	gitc.EXPECT().Push("saturn-bot--unittest").Return(nil)
-	tw := &task.Task{Task: schema.Task{CommitMessage: "commit test", Name: "unittest"}}
+	tw := &task.Task{Task: schema.Task{CommitMessage: "commit test", Name: "unittest", ChangeLimit: 1}}
 	tw.AddPreCloneFilters(&trueFilter{})
 
 	p := &processor.Processor{Git: gitc}
@@ -89,6 +89,7 @@ func TestProcessor_Process_CreatePullRequestLocalChanges(t *testing.T) {
 	assert.Len(t, results, 1)
 	assert.Equal(t, processor.ResultPrCreated, results[0].Result)
 	assert.Equal(t, prCreate, results[0].PullRequest)
+	assert.True(t, tw.HasReachedChangeLimit(), "Updates the change limit")
 	assert.NoError(t, results[0].Error)
 }
 

--- a/test/mock/processor/processor.gen.go
+++ b/test/mock/processor/processor.gen.go
@@ -10,7 +10,6 @@
 package processor
 
 import (
-	context "context"
 	reflect "reflect"
 
 	host "github.com/wndhydrnt/saturn-bot/pkg/host"
@@ -46,17 +45,15 @@ func (m *MockRepositoryTaskProcessor) EXPECT() *MockRepositoryTaskProcessorMockR
 }
 
 // Process mocks base method.
-func (m *MockRepositoryTaskProcessor) Process(ctx context.Context, dryRun bool, repo host.Repository, task *task.Task, doFilter bool) (processor.Result, *host.PullRequest, error) {
+func (m *MockRepositoryTaskProcessor) Process(dryRun bool, repo host.Repository, tasks []*task.Task, doFilter bool) []processor.ProcessResult {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Process", ctx, dryRun, repo, task, doFilter)
-	ret0, _ := ret[0].(processor.Result)
-	ret1, _ := ret[1].(*host.PullRequest)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "Process", dryRun, repo, tasks, doFilter)
+	ret0, _ := ret[0].([]processor.ProcessResult)
+	return ret0
 }
 
 // Process indicates an expected call of Process.
-func (mr *MockRepositoryTaskProcessorMockRecorder) Process(ctx, dryRun, repo, task, doFilter any) *gomock.Call {
+func (mr *MockRepositoryTaskProcessorMockRecorder) Process(dryRun, repo, tasks, doFilter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*MockRepositoryTaskProcessor)(nil).Process), ctx, dryRun, repo, task, doFilter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Process", reflect.TypeOf((*MockRepositoryTaskProcessor)(nil).Process), dryRun, repo, tasks, doFilter)
 }


### PR DESCRIPTION
Before this change, a `git clone` or `git pull` is executed for each repository/task combincation.
With this change, `git clone` or `git pull` gets only executed once per repository.

Follow-up to #132.