### PR TITLE
feat(task): Add option to push to the default branch of a repository

### DIFF
--- a/docs/task/index.md
+++ b/docs/task/index.md
@@ -239,6 +239,22 @@ prTitle: "feat: Custom title"
 prTitle: "Apply task {{.TaskName}}"
 ```
 
+## pushToDefaultBranch
+
+[json-path:../../pkg/task/schema/task.schema.json:$.properties.pushToDefaultBranch.description]
+
+Defaults to `false`.
+
+Examples
+
+```yaml title="Create a pull request if task changes content"
+pushToDefaultBranch: false
+```
+
+```yaml title="Push changes to the default branch"
+pushToDefaultBranch: true
+```
+
 ## reviewers
 
 [json-path:../../pkg/task/schema/task.schema.json:$.properties.reviewers.description]

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -59,7 +59,7 @@ type GitClient interface {
 	HasLocalChanges() (bool, error)
 	HasRemoteChanges(branchName string) (bool, error)
 	Prepare(repo host.Repository, retry bool) (string, error)
-	Push(branchName string) error
+	Push(branchName string, force bool) error
 	UpdateTaskBranch(branchName string, forceRebase bool, repo host.Repository) (bool, error)
 }
 
@@ -250,8 +250,13 @@ func (g *Git) HasRemoteChanges(branchName string) (bool, error) {
 	return strings.TrimSpace(stdout) != "", nil
 }
 
-func (g *Git) Push(branchName string) error {
-	_, _, err := g.Execute("push", "origin", branchName, "--force", "--set-upstream")
+func (g *Git) Push(branchName string, force bool) error {
+	args := []string{"push", "origin", branchName, "--set-upstream"}
+	if force {
+		args = append(args, "--force")
+	}
+
+	_, _, err := g.Execute(args...)
 	if err != nil {
 		return fmt.Errorf("git push to branch %s failed: %w", branchName, err)
 	}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -531,7 +531,7 @@ func TestGit_HasRemoteChanges_ErrorDiff(t *testing.T) {
 
 func TestGit_Push_Success(t *testing.T) {
 	em := &execMock{t: t}
-	em.withCall("git", "push", "origin", "unittest", "--force", "--set-upstream")
+	em.withCall("git", "push", "origin", "unittest", "--set-upstream", "--force")
 
 	g, err := git.New(setupOpts(config.Configuration{
 		DataDir: toPtr("/tmp"),
@@ -539,7 +539,7 @@ func TestGit_Push_Success(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	g.CmdExec = em.exec
-	err = g.Push("unittest")
+	err = g.Push("unittest", true)
 
 	assert.NoError(t, err)
 	assert.True(t, em.finished())
@@ -547,7 +547,7 @@ func TestGit_Push_Success(t *testing.T) {
 
 func TestGit_Push_Failure(t *testing.T) {
 	em := &execMock{t: t}
-	em.withCall("git", "push", "origin", "unittest", "--force", "--set-upstream").withErrorMsg("push failed")
+	em.withCall("git", "push", "origin", "unittest", "--set-upstream", "--force").withErrorMsg("push failed")
 
 	g, err := git.New(setupOpts(config.Configuration{
 		DataDir: toPtr("/tmp"),
@@ -555,7 +555,7 @@ func TestGit_Push_Failure(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	g.CmdExec = em.exec
-	err = g.Push("unittest")
+	err = g.Push("unittest", true)
 
 	assert.Error(t, err)
 	assert.True(t, em.finished())

--- a/pkg/processor/result_string.go
+++ b/pkg/processor/result_string.go
@@ -22,11 +22,12 @@ func _() {
 	_ = x[ResultPrOpen-11]
 	_ = x[ResultNoMatch-12]
 	_ = x[ResultSkip-13]
+	_ = x[ResultPushedDefaultBranch-14]
 }
 
-const _Result_name = "ResultUnknownResultAutoMergeTooEarlyResultBranchModifiedResultChecksFailedResultConflictResultNoChangesResultPrCreatedResultPrClosedBeforeResultPrClosedResultPrMergedBeforeResultPrMergedResultPrOpenResultNoMatchResultSkip"
+const _Result_name = "ResultUnknownResultAutoMergeTooEarlyResultBranchModifiedResultChecksFailedResultConflictResultNoChangesResultPrCreatedResultPrClosedBeforeResultPrClosedResultPrMergedBeforeResultPrMergedResultPrOpenResultNoMatchResultSkipResultPushedDefaultBranch"
 
-var _Result_index = [...]uint8{0, 13, 36, 56, 74, 88, 103, 118, 138, 152, 172, 186, 198, 211, 221}
+var _Result_index = [...]uint8{0, 13, 36, 56, 74, 88, 103, 118, 138, 152, 172, 186, 198, 211, 221, 246}
 
 func (i Result) String() string {
 	if i < 0 || i >= Result(len(_Result_index)-1) {

--- a/pkg/task/schema/schema.gen.go
+++ b/pkg/task/schema/schema.gen.go
@@ -312,6 +312,10 @@ type Task struct {
 	// If set, used as the title of the pull request.
 	PrTitle string `json:"prTitle,omitempty" yaml:"prTitle,omitempty" mapstructure:"prTitle,omitempty"`
 
+	// If `true`, push changes directly to the default branch, like "main". If
+	// `false`, create a pull request to submit changes.
+	PushToDefaultBranch bool `json:"pushToDefaultBranch,omitempty" yaml:"pushToDefaultBranch,omitempty" mapstructure:"pushToDefaultBranch,omitempty"`
+
 	// A list of usernames to set as reviewers of the pull request.
 	Reviewers []string `json:"reviewers,omitempty" yaml:"reviewers,omitempty" mapstructure:"reviewers,omitempty"`
 
@@ -429,6 +433,9 @@ func (j *Task) UnmarshalJSON(b []byte) error {
 	if v, ok := raw["prTitle"]; !ok || v == nil {
 		plain.PrTitle = ""
 	}
+	if v, ok := raw["pushToDefaultBranch"]; !ok || v == nil {
+		plain.PushToDefaultBranch = false
+	}
 	*j = Task(plain)
 	return nil
 }
@@ -485,6 +492,9 @@ func (j *Task) UnmarshalYAML(value *yaml.Node) error {
 	}
 	if v, ok := raw["prTitle"]; !ok || v == nil {
 		plain.PrTitle = ""
+	}
+	if v, ok := raw["pushToDefaultBranch"]; !ok || v == nil {
+		plain.PushToDefaultBranch = false
 	}
 	*j = Task(plain)
 	return nil

--- a/pkg/task/schema/task.schema.json
+++ b/pkg/task/schema/task.schema.json
@@ -116,6 +116,11 @@
       "description": "If set, used as the title of the pull request.",
       "type": "string"
     },
+    "pushToDefaultBranch": {
+      "default": false,
+      "description": "If `true`, push changes directly to the default branch, like \"main\". If `false`, create a pull request to submit changes.",
+      "type": "boolean"
+    },
     "reviewers": {
       "description": "A list of usernames to set as reviewers of the pull request.",
       "type": "array",

--- a/test/mock/git/git.gen.go
+++ b/test/mock/git/git.gen.go
@@ -134,17 +134,17 @@ func (mr *MockGitClientMockRecorder) Prepare(repo, retry any) *gomock.Call {
 }
 
 // Push mocks base method.
-func (m *MockGitClient) Push(branchName string) error {
+func (m *MockGitClient) Push(branchName string, force bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Push", branchName)
+	ret := m.ctrl.Call(m, "Push", branchName, force)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Push indicates an expected call of Push.
-func (mr *MockGitClientMockRecorder) Push(branchName any) *gomock.Call {
+func (mr *MockGitClientMockRecorder) Push(branchName, force any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockGitClient)(nil).Push), branchName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockGitClient)(nil).Push), branchName, force)
 }
 
 // UpdateTaskBranch mocks base method.


### PR DESCRIPTION
Sometimes creating a pull request isn't the desired outcome. For example, if a repository is used to back up data.

- Add field `pushToDefaultBranch` to schema of a Task.
- Implement functionality.
- Update documentation.