### PR TITLE
feat(server): Render Markdown in description of input in the UI

### DIFF
--- a/docs/reference/task/inputs.md
+++ b/docs/reference/task/inputs.md
@@ -19,13 +19,17 @@ inputs:
     validation: "^Hello|Hola$"
   # Optional input because a default value is set.
   - name: to
-    description: Whom to great.
+    description: Whom to great. # (1)
     default: World
     # Optional list of allowed values
     options:
       - World
       - Mundo
 ```
+
+1.  The server UI supports Markdown formatting in this field.
+    For example, `**bold**` gets rendered as **bold** by the UI.
+    Links work too.
 
 Each input is passed to `saturn-bot run`:
 

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20250207164621-7a1f277a159e // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/gomarkdown/markdown v0.0.0-20250207164621-7a1f277a159e h1:ESHlT0RVZphh4JGBz49I5R6nTdC8Qyc08vU25GQHzzQ=
+github.com/gomarkdown/markdown v0.0.0-20250207164621-7a1f277a159e/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/pkg/server/ui/templates.go
+++ b/pkg/server/ui/templates.go
@@ -108,7 +108,7 @@ func renderMarkdown(input string) template.HTML {
 	if len(doc.GetChildren()) < 1 {
 		// Return the escaped string if, for some reason,
 		// the parser didn't find a node.
-		return template.HTML(escaped)
+		return template.HTML(escaped) //nolint:gosec Input gets escaped above
 	}
 
 	// The parser always wraps the content in a paragraph (<p>).
@@ -118,7 +118,7 @@ func renderMarkdown(input string) template.HTML {
 	htmlFlags := html.CommonFlags | html.HrefTargetBlank
 	opts := html.RendererOptions{Flags: htmlFlags}
 	renderer := html.NewRenderer(opts)
-	return template.HTML(markdown.Render(doc, renderer))
+	return template.HTML(markdown.Render(doc, renderer)) //nolint:gosec Input gets escaped above
 }
 
 func renderTemplate(data any, w http.ResponseWriter, names ...string) {

--- a/pkg/server/ui/templates.go
+++ b/pkg/server/ui/templates.go
@@ -108,7 +108,7 @@ func renderMarkdown(input string) template.HTML {
 	if len(doc.GetChildren()) < 1 {
 		// Return the escaped string if, for some reason,
 		// the parser didn't find a node.
-		return template.HTML(escaped) //nolint:gosec Input gets escaped above
+		return template.HTML(escaped) //nolint:gosec // input gets escaped above
 	}
 
 	// The parser always wraps the content in a paragraph (<p>).
@@ -118,7 +118,7 @@ func renderMarkdown(input string) template.HTML {
 	htmlFlags := html.CommonFlags | html.HrefTargetBlank
 	opts := html.RendererOptions{Flags: htmlFlags}
 	renderer := html.NewRenderer(opts)
-	return template.HTML(markdown.Render(doc, renderer)) //nolint:gosec Input gets escaped above
+	return template.HTML(markdown.Render(doc, renderer)) //nolint:gosec // input gets escaped above
 }
 
 func renderTemplate(data any, w http.ResponseWriter, names ...string) {

--- a/pkg/server/ui/templates/task-run-new.html
+++ b/pkg/server/ui/templates/task-run-new.html
@@ -38,7 +38,7 @@
         </div>
         {{end}}
         <p class="help">
-          {{.Description}}
+          {{.Description | markdown}}
           {{if .Validation}}
           Must match regular expression <code>{{.Validation}}</code>.
           {{end}}


### PR DESCRIPTION
`inputs[].description` can contain Markdown instructions.
The UI can turn Markdown to HTML.