### PR TITLE
fix(worker): Plugins do not start

### DIFF
--- a/pkg/host/cache.go
+++ b/pkg/host/cache.go
@@ -52,7 +52,13 @@ func (rc *RepositoryFileCache) List(hosts []Host, result chan Repository, errCha
 
 func (rc *RepositoryFileCache) remove(repo Repository) error {
 	d := filepath.Join(rc.Dir, repo.FullName())
-	return os.RemoveAll(d)
+	_, err := os.Stat(d)
+	if err == nil {
+		log.Log().Debugf("Removing archived repository from file cache %s", repo.FullName())
+		return os.RemoveAll(d)
+	}
+
+	return nil
 }
 
 func (rc *RepositoryFileCache) readLastUpdateTimestamp(h Host) (*time.Time, error) {
@@ -197,7 +203,6 @@ func (rc *RepositoryFileCache) receiveRepositories(expectedFinishes int, results
 		case repoList := <-results:
 			for _, repo := range repoList {
 				if repo.IsArchived() {
-					log.Log().Debugf("Removing archived repository from file cache %s", repo.FullName())
 					_ = rc.remove(repo)
 					continue
 				}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -123,10 +123,17 @@ func NewWorker(configPath string, taskPaths []string) (*Worker, error) {
 		return nil, err
 	}
 
-	// The registry holds tasks for validation.
-	// No need to start plugins here.
-	opts.SkipPlugins = true
-	reg := task.NewRegistry(opts)
+	reg := task.NewRegistry(options.Opts{
+		ActionFactories: opts.ActionFactories,
+		Config:          opts.Config,
+		Clock:           opts.Clock,
+		FilterFactories: opts.FilterFactories,
+		Hosts:           opts.Hosts,
+		IsCi:            opts.IsCi,
+		// This registry holds tasks to perform validation.
+		// No need to start plugins here.
+		SkipPlugins: true,
+	})
 	err = reg.ReadAll(taskPaths)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Pass a new instance of `options.Opts` to the task registry that reads the tasks that are used for validation.

Previous implementation used the same instance of `options.Opts`, which inadvertently caused the worker to not start plugins.