### PR TITLE
feat(task): Keep run data that isn't defined in inputs

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -74,7 +74,7 @@ func (p *Processor) Process(dryRun bool, repo host.Repository, tasks []*task.Tas
 
 		taskLogger := logger.With(log.FieldTask(t.Name))
 		taskCtx := sbcontext.WithLog(ctx, taskLogger)
-		taskCtx = sbcontext.WithRunData(taskCtx, t.InputData())
+		taskCtx = sbcontext.WithRunData(taskCtx, t.RunData())
 		match, preCloneResult, err := p.filterPreClone(taskCtx, t)
 		result := ProcessResult{
 			Task: t,
@@ -127,7 +127,7 @@ func (p *Processor) Process(dryRun bool, repo host.Repository, tasks []*task.Tas
 				log.FieldTask(t.Name),
 			))
 		taskCtx := sbcontext.WithLog(ctx, taskLogger)
-		taskCtx = sbcontext.WithRunData(taskCtx, t.InputData())
+		taskCtx = sbcontext.WithRunData(taskCtx, t.RunData())
 		resultId, pr, err := p.processPostClone(taskCtx, repo, t, doFilter, dryRun)
 		result := ProcessResult{
 			PullRequest: pr,

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -271,6 +271,15 @@ func TestTask_Inputs(t *testing.T) {
 			inputs: map[string]string{},
 			err:    errors.New("input unittest not set and has no default value"),
 		},
+
+		{
+			name: "keeps run data items for which no input has been specified",
+			task: schema.Task{Inputs: []schema.Input{
+				{Name: "category"},
+			}},
+			inputs: map[string]string{"category": "unittest", "type": "table"},
+			result: map[string]string{"category": "unittest", "type": "table"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -279,7 +288,7 @@ func TestTask_Inputs(t *testing.T) {
 			err := tw.SetInputs(tc.inputs)
 			if tc.err == nil {
 				require.NoError(t, err)
-				require.Equal(t, tc.result, tw.InputData())
+				require.Equal(t, tc.result, tw.RunData())
 			} else {
 				require.EqualError(t, err, tc.err.Error())
 			}

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -295,3 +295,26 @@ func TestTask_Inputs(t *testing.T) {
 		})
 	}
 }
+
+func TestTask_SetInputs_NoSharedState(t *testing.T) {
+	taskOne := &task.Task{Task: schema.Task{
+		Name: "Task One",
+		Inputs: []schema.Input{
+			{Default: ptr.To("joel"), Name: "character"},
+		},
+	}}
+	taskTwo := &task.Task{Task: schema.Task{
+		Name: "Task Two",
+		Inputs: []schema.Input{
+			{Default: ptr.To("tommy"), Name: "character"},
+		},
+	}}
+	runData := map[string]string{}
+
+	taskOne.SetInputs(runData)
+	taskTwo.SetInputs(runData)
+
+	require.Equal(t, map[string]string{"character": "joel"}, taskOne.RunData(), "default value in run data")
+	require.Equal(t, map[string]string{"character": "tommy"}, taskTwo.RunData(), "default value in run data")
+	require.Equal(t, map[string]string{}, runData, "state of global run data has not changed")
+}

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -311,8 +311,10 @@ func TestTask_SetInputs_NoSharedState(t *testing.T) {
 	}}
 	runData := map[string]string{}
 
-	taskOne.SetInputs(runData)
-	taskTwo.SetInputs(runData)
+	err := taskOne.SetInputs(runData)
+	require.NoError(t, err)
+	err = taskTwo.SetInputs(runData)
+	require.NoError(t, err)
 
 	require.Equal(t, map[string]string{"character": "joel"}, taskOne.RunData(), "default value in run data")
 	require.Equal(t, map[string]string{"character": "tommy"}, taskTwo.RunData(), "default value in run data")


### PR DESCRIPTION
A task drops the keys from the run data struct if the keys aren't defined as inputs.

This change keeps the "unknown" keys.
The intention is to make it easier to work with tasks that get scheduled via an API call to `ScheduleRunV1` or webhooks.
Users don't have to define both `inputs` and `runData` in that case.
A user can still define an `input` if validation is a requirement.