### PR TITLE
fix(server): Update status of PR when user merges PR and filter does not match

### DIFF
--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -360,8 +360,6 @@ func shouldReport(result processor.Result) bool {
 	switch result {
 	case processor.ResultNoChanges:
 		return false
-	case processor.ResultNoMatch:
-		return false
 	case processor.ResultSkip:
 		return false
 	default:


### PR DESCRIPTION
- Make worker component send results when a repository does not match.
- Let server component handle the new results. Mark a pull request as "merged" when the server has a record of it being open and now the task doesn't match the repository.