### PR TITLE
refactor(host): Use PullRequest struct to handle pull request data

### DIFF
--- a/pkg/host/github.go
+++ b/pkg/host/github.go
@@ -33,8 +33,8 @@ func (g *GitHubRepository) BaseBranch() string {
 	return g.repo.GetDefaultBranch()
 }
 
-func (g *GitHubRepository) CanMergePullRequest(pr interface{}) (bool, error) {
-	gpr := pr.(*github.PullRequest)
+func (g *GitHubRepository) CanMergePullRequest(pr *PullRequest) (bool, error) {
+	gpr := pr.Raw.(*github.PullRequest)
 	if gpr.Mergeable == nil {
 		return true, nil
 	}
@@ -50,8 +50,8 @@ func (g *GitHubRepository) CloneUrlSsh() string {
 	return g.repo.GetSSHURL()
 }
 
-func (g *GitHubRepository) ClosePullRequest(msg string, pr interface{}) error {
-	gpr := pr.(*github.PullRequest)
+func (g *GitHubRepository) ClosePullRequest(msg string, pr *PullRequest) error {
+	gpr := pr.Raw.(*github.PullRequest)
 	comment := &github.IssueComment{Body: github.Ptr(msg)}
 	_, _, err := g.client.Issues.CreateComment(ctx, g.repo.GetOwner().GetLogin(), g.repo.GetName(), gpr.GetNumber(), comment)
 	if err != nil {
@@ -67,8 +67,8 @@ func (g *GitHubRepository) ClosePullRequest(msg string, pr interface{}) error {
 	return nil
 }
 
-func (g *GitHubRepository) CreatePullRequestComment(body string, pr interface{}) error {
-	gpr := pr.(*github.PullRequest)
+func (g *GitHubRepository) CreatePullRequestComment(body string, pr *PullRequest) error {
+	gpr := pr.Raw.(*github.PullRequest)
 	comment := &github.IssueComment{Body: github.Ptr(body)}
 	_, _, err := g.client.Issues.CreateComment(ctx, g.repo.GetOwner().GetLogin(), g.repo.GetName(), gpr.GetNumber(), comment)
 	if err != nil {
@@ -119,7 +119,7 @@ func (g *GitHubRepository) CreatePullRequest(branch string, data PullRequestData
 	return g.PullRequest(pr), nil
 }
 
-func (g *GitHubRepository) FindPullRequest(branch string) (any, error) {
+func (g *GitHubRepository) FindPullRequest(branch string) (*PullRequest, error) {
 	opts := &github.PullRequestListOptions{
 		State: "all",
 		ListOptions: github.ListOptions{
@@ -135,7 +135,7 @@ func (g *GitHubRepository) FindPullRequest(branch string) (any, error) {
 
 		for _, pr := range prs {
 			if pr.GetHead().GetRef() == branch {
-				return pr, nil
+				return g.PullRequest(pr), nil
 			}
 		}
 
@@ -151,23 +151,18 @@ func (g *GitHubRepository) FullName() string {
 	return fmt.Sprintf("github.com/%s/%s", g.repo.GetOwner().GetLogin(), g.repo.GetName())
 }
 
-func (g *GitHubRepository) GetPullRequestBody(pr interface{}) string {
-	gpr := pr.(*github.PullRequest)
+func (g *GitHubRepository) GetPullRequestBody(pr *PullRequest) string {
+	gpr := pr.Raw.(*github.PullRequest)
 	return gpr.GetBody()
 }
 
-func (g *GitHubRepository) GetPullRequestCreationTime(pr interface{}) time.Time {
-	gpr := pr.(*github.PullRequest)
-	return gpr.GetCreatedAt().Time
-}
-
-func (g *GitHubRepository) DeleteBranch(pr interface{}) error {
+func (g *GitHubRepository) DeleteBranch(pr *PullRequest) error {
 	// GitHub handles deletion
 	if g.repo.GetDeleteBranchOnMerge() {
 		return nil
 	}
 
-	gpr := pr.(*github.PullRequest)
+	gpr := pr.Raw.(*github.PullRequest)
 	_, err := g.client.Git.DeleteRef(ctx, g.repo.GetOwner().GetLogin(), g.repo.GetName(), "heads/"+gpr.GetHead().GetRef())
 	if err != nil {
 		return fmt.Errorf("delete GitHub branch %s: %w", gpr.GetHead().GetRef(), err)
@@ -176,7 +171,7 @@ func (g *GitHubRepository) DeleteBranch(pr interface{}) error {
 	return nil
 }
 
-func (g *GitHubRepository) DeletePullRequestComment(comment PullRequestComment, pr interface{}) error {
+func (g *GitHubRepository) DeletePullRequestComment(comment PullRequestComment, _ *PullRequest) error {
 	_, err := g.client.Issues.DeleteComment(ctx, g.repo.GetOwner().GetLogin(), g.repo.GetName(), comment.ID)
 	if err != nil {
 		return fmt.Errorf("delete pull request comment with ID %d: %w", comment.ID, err)
@@ -185,8 +180,8 @@ func (g *GitHubRepository) DeletePullRequestComment(comment PullRequestComment, 
 	return nil
 }
 
-func (g *GitHubRepository) HasSuccessfulPullRequestBuild(pr interface{}) (bool, error) {
-	gpr := pr.(*github.PullRequest)
+func (g *GitHubRepository) HasSuccessfulPullRequestBuild(pr *PullRequest) (bool, error) {
+	gpr := pr.Raw.(*github.PullRequest)
 	opts := &github.ListCheckRunsOptions{
 		ListOptions: github.ListOptions{
 			Page:    1,
@@ -227,7 +222,7 @@ func (g *GitHubRepository) ID() int64 {
 // IsPullRequestClosed implements [Repository].
 // Note: uses MergedAt attribute instead of Merged
 // because Merge attribute isn't set when listing pull requests via the GitHub API.
-func (g *GitHubRepository) IsPullRequestClosed(pr interface{}) bool {
+func (g *GitHubRepository) IsPullRequestClosed(pr PullRequestRaw) bool {
 	gpr := pr.(*github.PullRequest)
 	return gpr.GetState() == "closed" && gpr.MergedAt == nil
 }
@@ -235,19 +230,19 @@ func (g *GitHubRepository) IsPullRequestClosed(pr interface{}) bool {
 // IsPullRequestMerged implements [Repository].
 // Note: uses MergedAt attribute instead of Merged
 // because Merge attribute isn't set when listing pull requests via the GitHub API.
-func (g *GitHubRepository) IsPullRequestMerged(pr interface{}) bool {
+func (g *GitHubRepository) IsPullRequestMerged(pr PullRequestRaw) bool {
 	gpr := pr.(*github.PullRequest)
 	return gpr.GetState() == "closed" && gpr.MergedAt != nil
 }
 
 // IsPullRequestOpen implements [Repository].
-func (g *GitHubRepository) IsPullRequestOpen(pr interface{}) bool {
+func (g *GitHubRepository) IsPullRequestOpen(pr PullRequestRaw) bool {
 	gpr := pr.(*github.PullRequest)
 	return gpr.GetState() == "open"
 }
 
-func (g *GitHubRepository) ListPullRequestComments(pr interface{}) ([]PullRequestComment, error) {
-	gpr := pr.(*github.PullRequest)
+func (g *GitHubRepository) ListPullRequestComments(pr *PullRequest) ([]PullRequestComment, error) {
+	gpr := pr.Raw.(*github.PullRequest)
 	opts := &github.IssueListCommentsOptions{
 		ListOptions: github.ListOptions{
 			Page:    1,
@@ -278,8 +273,8 @@ func (g *GitHubRepository) ListPullRequestComments(pr interface{}) ([]PullReques
 	return pullRequestComments, nil
 }
 
-func (g *GitHubRepository) MergePullRequest(deleteBranch bool, pr interface{}) error {
-	gpr := pr.(*github.PullRequest)
+func (g *GitHubRepository) MergePullRequest(deleteBranch bool, pr *PullRequest) error {
+	gpr := pr.Raw.(*github.PullRequest)
 	opts := &github.PullRequestOptions{
 		MergeMethod: g.determineMergeMethod(),
 	}
@@ -330,15 +325,16 @@ func (g *GitHubRepository) PullRequest(pr any) *PullRequest {
 	}
 
 	return &PullRequest{
-		CreatedAt: &gpr.CreatedAt.Time,
+		CreatedAt: gpr.GetCreatedAt().Time,
 		Number:    int64(gpr.GetNumber()),
 		WebURL:    gpr.GetHTMLURL(),
+		Raw:       gpr,
 		State:     g.mapToPullRequestState(gpr),
 	}
 }
 
-func (g *GitHubRepository) UpdatePullRequest(data PullRequestData, pr interface{}) error {
-	gpr := pr.(*github.PullRequest)
+func (g *GitHubRepository) UpdatePullRequest(data PullRequestData, pr *PullRequest) error {
+	gpr := pr.Raw.(*github.PullRequest)
 	needsUpdate := false
 	if gpr.GetTitle() != data.Title {
 		needsUpdate = true

--- a/pkg/host/github_test.go
+++ b/pkg/host/github_test.go
@@ -47,7 +47,7 @@ func TestGitHubRepository_CanMergePullRequest(t *testing.T) {
 	}
 
 	repo := &GitHubRepository{}
-	result, err := repo.CanMergePullRequest(pr)
+	result, err := repo.CanMergePullRequest(toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, result)
@@ -57,7 +57,7 @@ func TestGitHubRepository_CanMergePullRequest_MergeableNil(t *testing.T) {
 	pr := &github.PullRequest{}
 
 	repo := &GitHubRepository{}
-	result, err := repo.CanMergePullRequest(pr)
+	result, err := repo.CanMergePullRequest(toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, result)
@@ -109,7 +109,7 @@ func TestGitHubRepository_ClosePullRequest(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.ClosePullRequest("close pull request", pr)
+	err := repo.ClosePullRequest("close pull request", toSbPr(pr))
 
 	require.NoError(t, err)
 	require.True(t, gock.IsDone())
@@ -133,7 +133,7 @@ func TestGitHubRepository_CreatePullRequestComment(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.CreatePullRequestComment("pull request comment", pr)
+	err := repo.CreatePullRequestComment("pull request comment", toSbPr(pr))
 
 	require.NoError(t, err)
 	require.True(t, gock.IsDone())
@@ -267,7 +267,13 @@ func TestGitHubRepository_FindPullRequest(t *testing.T) {
 		Reply(200).
 		JSON([]*github.PullRequest{
 			{Head: &github.PullRequestBranch{Ref: github.Ptr("other")}},
-			{Head: &github.PullRequestBranch{Ref: github.Ptr("unittest")}},
+			{
+				CreatedAt: &github.Timestamp{Time: time.Now()},
+				HTMLURL:   github.Ptr("https://github.com/unit/test/pulls/1"),
+				Head:      &github.PullRequestBranch{Ref: github.Ptr("unittest")},
+				Number:    github.Ptr(123),
+				State:     github.Ptr("open"),
+			},
 		})
 
 	repo := &GitHubRepository{
@@ -277,7 +283,11 @@ func TestGitHubRepository_FindPullRequest(t *testing.T) {
 	prId, err := repo.FindPullRequest("unittest")
 
 	require.NoError(t, err)
-	assert.IsType(t, &github.PullRequest{}, prId)
+	assert.IsType(t, time.Time{}, prId.CreatedAt)
+	assert.Equal(t, int64(123), prId.Number)
+	assert.Equal(t, "https://github.com/unit/test/pulls/1", prId.WebURL)
+	assert.IsType(t, &github.PullRequest{}, prId.Raw)
+	assert.Equal(t, PullRequestStateOpen, prId.State)
 	assert.True(t, gock.IsDone())
 }
 
@@ -319,20 +329,9 @@ func TestGitHubRepository_GetPullRequestBody(t *testing.T) {
 		Body: github.Ptr("pull request body"),
 	}
 	repo := &GitHubRepository{repo: setupGitHubRepository()}
-	body := repo.GetPullRequestBody(pr)
+	body := repo.GetPullRequestBody(toSbPr(pr))
 
 	assert.Equal(t, "pull request body", body)
-}
-
-func TestGitHubRepository_GetPullRequestCreationTime(t *testing.T) {
-	now := time.Now()
-	pr := &github.PullRequest{
-		CreatedAt: &github.Timestamp{Time: now},
-	}
-	repo := &GitHubRepository{repo: setupGitHubRepository()}
-	createdAt := repo.GetPullRequestCreationTime(pr)
-
-	assert.Equal(t, now, createdAt)
 }
 
 func TestGitHubRepository_DeleteBranch(t *testing.T) {
@@ -351,7 +350,7 @@ func TestGitHubRepository_DeleteBranch(t *testing.T) {
 			Ref: github.Ptr("unittest"),
 		},
 	}
-	err := repo.DeleteBranch(pr)
+	err := repo.DeleteBranch(toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -371,7 +370,7 @@ func TestGitHubRepository_DeleteBranch_RepoAutoDelete(t *testing.T) {
 			Ref: github.Ptr("unittest"),
 		},
 	}
-	err := repo.DeleteBranch(pr)
+	err := repo.DeleteBranch(toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -391,7 +390,7 @@ func TestGitHubRepository_DeletePullRequestComment(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.DeletePullRequestComment(comment, pr)
+	err := repo.DeletePullRequestComment(comment, toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -421,7 +420,7 @@ func TestGitHubRepository_HasSuccessfulPullRequestBuild_Success(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	result, err := repo.HasSuccessfulPullRequestBuild(pr)
+	result, err := repo.HasSuccessfulPullRequestBuild(toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, result)
@@ -452,7 +451,7 @@ func TestGitHubRepository_HasSuccessfulPullRequestBuild_Failed(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	result, err := repo.HasSuccessfulPullRequestBuild(pr)
+	result, err := repo.HasSuccessfulPullRequestBuild(toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.False(t, result)
@@ -537,7 +536,7 @@ func TestGitHubRepository_ListPullRequestComments(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	result, err := repo.ListPullRequestComments(pr)
+	result, err := repo.ListPullRequestComments(toSbPr(pr))
 
 	require.NoError(t, err)
 	comment := PullRequestComment{Body: "comment body", ID: 357}
@@ -561,7 +560,7 @@ func TestGitHubRepository_MergePullRequest_NoDeleteBranch(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.MergePullRequest(false, pr)
+	err := repo.MergePullRequest(false, toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -589,7 +588,7 @@ func TestGitHubRepository_MergePullRequest_DeleteBranch(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.MergePullRequest(true, pr)
+	err := repo.MergePullRequest(true, toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -616,7 +615,7 @@ func TestGitHubRepository_MergePullRequest_DeleteBranchByGitHub(t *testing.T) {
 		client: setupGitHubTestClient(),
 		repo:   ghRepo,
 	}
-	err := repo.MergePullRequest(true, pr)
+	err := repo.MergePullRequest(true, toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -673,7 +672,7 @@ func TestGitHubRepository_MergePullRequest_MergeMethods(t *testing.T) {
 				client: setupGitHubTestClient(),
 				repo:   tc.repo,
 			}
-			err := repo.MergePullRequest(false, pr)
+			err := repo.MergePullRequest(false, toSbPr(pr))
 
 			require.NoError(t, err)
 			assert.True(t, gock.IsDone())
@@ -721,7 +720,7 @@ _This pull request has been created by [saturn-bot](https://github.com/wndhydrnt
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.UpdatePullRequest(prData, pr)
+	err := repo.UpdatePullRequest(prData, toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -760,7 +759,7 @@ _This pull request has been created by [saturn-bot](https://github.com/wndhydrnt
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.UpdatePullRequest(prData, pr)
+	err := repo.UpdatePullRequest(prData, toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -817,7 +816,7 @@ _This pull request has been created by [saturn-bot](https://github.com/wndhydrnt
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.UpdatePullRequest(prData, pr)
+	err := repo.UpdatePullRequest(prData, toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())
@@ -881,7 +880,7 @@ _This pull request has been created by [saturn-bot](https://github.com/wndhydrnt
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.UpdatePullRequest(prData, pr)
+	err := repo.UpdatePullRequest(prData, toSbPr(pr))
 
 	require.NoError(t, err)
 	assert.True(t, gock.IsDone())

--- a/pkg/host/github_test.go
+++ b/pkg/host/github_test.go
@@ -283,7 +283,7 @@ func TestGitHubRepository_FindPullRequest(t *testing.T) {
 	prId, err := repo.FindPullRequest("unittest")
 
 	require.NoError(t, err)
-	assert.IsType(t, time.Time{}, prId.CreatedAt)
+	assert.False(t, prId.CreatedAt.IsZero())
 	assert.Equal(t, int64(123), prId.Number)
 	assert.Equal(t, "https://github.com/unit/test/pulls/1", prId.WebURL)
 	assert.IsType(t, &github.PullRequest{}, prId.Raw)

--- a/pkg/host/gitlab.go
+++ b/pkg/host/gitlab.go
@@ -84,26 +84,21 @@ func (g *GitLabRepository) FullName() string {
 	return g.fullName
 }
 
-func (g *GitLabRepository) GetPullRequestBody(pr interface{}) string {
-	mr := pr.(*gitlab.MergeRequest)
+func (g *GitLabRepository) GetPullRequestBody(pr *PullRequest) string {
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	return mr.Description
-}
-
-func (g *GitLabRepository) GetPullRequestCreationTime(pr interface{}) time.Time {
-	mr := pr.(*gitlab.MergeRequest)
-	return *mr.CreatedAt
 }
 
 func (g *GitLabRepository) WebUrl() string {
 	return g.project.WebURL
 }
 
-func (g *GitLabRepository) CanMergePullRequest(pr interface{}) (bool, error) {
+func (g *GitLabRepository) CanMergePullRequest(_ *PullRequest) (bool, error) {
 	return true, nil
 }
 
-func (g *GitLabRepository) ClosePullRequest(msg string, pr interface{}) error {
-	mr := pr.(*gitlab.MergeRequest)
+func (g *GitLabRepository) ClosePullRequest(msg string, pr *PullRequest) error {
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	_, _, err := g.client.Notes.CreateMergeRequestNote(
 		g.project.ID,
 		mr.IID,
@@ -129,8 +124,8 @@ func (g *GitLabRepository) ClosePullRequest(msg string, pr interface{}) error {
 	return nil
 }
 
-func (g *GitLabRepository) CreatePullRequestComment(body string, pr interface{}) error {
-	mr := pr.(*gitlab.MergeRequest)
+func (g *GitLabRepository) CreatePullRequestComment(body string, pr *PullRequest) error {
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	_, _, err := g.client.Notes.CreateMergeRequestNote(
 		g.project.ID,
 		mr.IID,
@@ -207,8 +202,8 @@ func (g *GitLabRepository) CreatePullRequest(branch string, data PullRequestData
 	return g.PullRequest(mr), nil
 }
 
-func (g *GitLabRepository) DeleteBranch(pr interface{}) error {
-	mr := pr.(*gitlab.MergeRequest)
+func (g *GitLabRepository) DeleteBranch(pr *PullRequest) error {
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	if mr.ShouldRemoveSourceBranch {
 		return nil
 	}
@@ -221,8 +216,8 @@ func (g *GitLabRepository) DeleteBranch(pr interface{}) error {
 	return nil
 }
 
-func (g *GitLabRepository) DeletePullRequestComment(comment PullRequestComment, pr interface{}) error {
-	mr := pr.(*gitlab.MergeRequest)
+func (g *GitLabRepository) DeletePullRequestComment(comment PullRequestComment, pr *PullRequest) error {
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	_, err := g.client.Notes.DeleteMergeRequestNote(g.project.ID, mr.IID, int(comment.ID))
 	if err != nil {
 		return fmt.Errorf("delete note of gitlab merge request %d project %d: %w", mr.IID, g.project.ID, err)
@@ -231,7 +226,7 @@ func (g *GitLabRepository) DeletePullRequestComment(comment PullRequestComment, 
 	return nil
 }
 
-func (g *GitLabRepository) FindPullRequest(branch string) (any, error) {
+func (g *GitLabRepository) FindPullRequest(branch string) (*PullRequest, error) {
 	mrs, _, err := g.client.MergeRequests.ListProjectMergeRequests(
 		g.project.ID,
 		&gitlab.ListProjectMergeRequestsOptions{
@@ -247,11 +242,11 @@ func (g *GitLabRepository) FindPullRequest(branch string) (any, error) {
 		return nil, ErrPullRequestNotFound
 	}
 
-	return mrs[0], nil
+	return g.PullRequest(mrs[0]), nil
 }
 
-func (g *GitLabRepository) HasSuccessfulPullRequestBuild(pr interface{}) (bool, error) {
-	mr := pr.(*gitlab.MergeRequest)
+func (g *GitLabRepository) HasSuccessfulPullRequestBuild(pr *PullRequest) (bool, error) {
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	state, _, err := g.client.MergeRequestApprovals.GetApprovalState(g.project.ID, mr.IID)
 	if err != nil {
 		return false, fmt.Errorf("get approval state of gitlab merge request %d project %d: %w", mr.IID, g.project.ID, err)
@@ -308,26 +303,26 @@ func (g *GitLabRepository) ID() int64 {
 
 func (g *GitLabRepository) IsPullRequestClosed(pr interface{}) bool {
 	mr := pr.(*gitlab.MergeRequest)
-	return mr.State == "closed" || mr.State == "locked"
+	return isPullRequestClosed(mr)
 }
 
 func (g *GitLabRepository) IsPullRequestMerged(pr interface{}) bool {
 	mr := pr.(*gitlab.MergeRequest)
-	return mr.State == "merged"
+	return isPullRequestMerged(mr)
 }
 
 func (g *GitLabRepository) IsPullRequestOpen(pr interface{}) bool {
 	mr := pr.(*gitlab.MergeRequest)
-	return mr.State == "opened"
+	return isPullRequestOpen(mr)
 }
 
-func (g *GitLabRepository) ListPullRequestComments(pr interface{}) ([]PullRequestComment, error) {
+func (g *GitLabRepository) ListPullRequestComments(pr *PullRequest) ([]PullRequestComment, error) {
 	var result []PullRequestComment
 	if pr == nil {
 		return result, nil
 	}
 
-	mr := pr.(*gitlab.MergeRequest)
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	opts := &gitlab.ListMergeRequestNotesOptions{
 		ListOptions: gitlab.ListOptions{
 			Page:    1,
@@ -354,8 +349,8 @@ func (g *GitLabRepository) ListPullRequestComments(pr interface{}) ([]PullReques
 	return result, nil
 }
 
-func (g *GitLabRepository) MergePullRequest(deleteBranch bool, pr interface{}) error {
-	mr := pr.(*gitlab.MergeRequest)
+func (g *GitLabRepository) MergePullRequest(deleteBranch bool, pr *PullRequest) error {
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	_, _, err := g.client.MergeRequests.AcceptMergeRequest(
 		g.project.ID,
 		mr.IID,
@@ -385,18 +380,24 @@ func (g *GitLabRepository) PullRequest(pr any) *PullRequest {
 		return nil
 	}
 
+	createdAt := time.Time{}
+	if mr.CreatedAt != nil {
+		createdAt = ptr.From(mr.CreatedAt)
+	}
+
 	return &PullRequest{
-		CreatedAt: mr.CreatedAt,
+		CreatedAt: createdAt,
 		Number:    int64(mr.IID),
 		WebURL:    mr.WebURL,
-		State:     mapToPullRequestStateGitLab(mr.State),
+		Raw:       pr,
+		State:     mapToPullRequestStateGitLab(mr),
 	}
 }
 
-func (g *GitLabRepository) UpdatePullRequest(data PullRequestData, pr interface{}) error {
+func (g *GitLabRepository) UpdatePullRequest(data PullRequestData, pr *PullRequest) error {
 	needsUpdate := false
 	opts := &gitlab.UpdateMergeRequestOptions{}
-	mr := pr.(*gitlab.MergeRequest)
+	mr := pr.Raw.(*gitlab.MergeRequest)
 	if mr.Title != data.Title {
 		opts.Title = gitlab.Ptr(data.Title)
 		needsUpdate = true
@@ -723,17 +724,30 @@ func (g *GitLabHost) SearchCode(gitlabGroupID any, query string) ([]int64, error
 	return slices.Compact(result), nil
 }
 
-func mapToPullRequestStateGitLab(mrState string) PullRequestState {
-	switch mrState {
-	case "closed":
+func isPullRequestClosed(mr *gitlab.MergeRequest) bool {
+	return mr.State == "closed" || mr.State == "locked"
+}
+
+func isPullRequestMerged(mr *gitlab.MergeRequest) bool {
+	return mr.State == "merged"
+}
+
+func isPullRequestOpen(mr *gitlab.MergeRequest) bool {
+	return mr.State == "opened"
+}
+
+func mapToPullRequestStateGitLab(mr *gitlab.MergeRequest) PullRequestState {
+	if isPullRequestClosed(mr) {
 		return PullRequestStateClosed
-	case "locked":
-		return PullRequestStateClosed
-	case "merged":
-		return PullRequestStateMerged
-	case "opened":
-		return PullRequestStateOpen
-	default:
-		return PullRequestStateUnknown
 	}
+
+	if isPullRequestMerged(mr) {
+		return PullRequestStateMerged
+	}
+
+	if isPullRequestOpen(mr) {
+		return PullRequestStateOpen
+	}
+
+	return PullRequestStateUnknown
 }

--- a/pkg/host/gitlab.go
+++ b/pkg/host/gitlab.go
@@ -389,7 +389,7 @@ func (g *GitLabRepository) PullRequest(pr any) *PullRequest {
 		CreatedAt: createdAt,
 		Number:    int64(mr.IID),
 		WebURL:    mr.WebURL,
-		Raw:       pr,
+		Raw:       mr,
 		State:     mapToPullRequestStateGitLab(mr),
 	}
 }

--- a/pkg/host/gitlab_test.go
+++ b/pkg/host/gitlab_test.go
@@ -344,7 +344,7 @@ func TestGitLabRepository_FindPullRequest(t *testing.T) {
 	result, err := underTest.FindPullRequest("saturn-bot--unit-test")
 
 	require.NoError(t, err)
-	require.IsType(t, time.Time{}, result.CreatedAt)
+	require.False(t, result.CreatedAt.IsZero())
 	require.Equal(t, int64(123), result.Number)
 	require.Equal(t, "https://gitlab.com/unit/test/-/merge_requests/123", result.WebURL)
 	require.IsType(t, &gitlab.MergeRequest{}, result.Raw)

--- a/pkg/host/suite_test.go
+++ b/pkg/host/suite_test.go
@@ -1,0 +1,7 @@
+package host
+
+func toSbPr(gpr any) *PullRequest {
+	return &PullRequest{
+		Raw: gpr,
+	}
+}

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -297,45 +297,42 @@ func applyTaskToRepository(ctx context.Context, dryRun bool, gitc git.GitClient,
 		return ResultUnknown, nil, fmt.Errorf("find pull request: %w", err)
 	}
 
-	prDetail := repo.PullRequest(prID)
-	if prID != nil && repo.IsPullRequestClosed(prID) {
+	if prID != nil && prID.State == host.PullRequestStateClosed {
 		if task.MergeOnce {
 			logger.Info("Existing PR has been closed")
-			return ResultPrClosedBefore, prDetail, nil
+			return ResultPrClosedBefore, prID, nil
 		} else {
 			logger.Debug("Previous pull request closed - resetting to create a new pull request")
 			prID = nil
 		}
 	}
 
-	if prID != nil && repo.IsPullRequestMerged(prID) && task.MergeOnce {
+	if prID != nil && prID.State == host.PullRequestStateMerged && task.MergeOnce {
 		logger.Info("Existing PR has been merged")
-		return ResultPrMergedBefore, prDetail, nil
+		return ResultPrMergedBefore, prID, nil
 	}
 
 	if prID != nil && task.CreateOnly {
 		logger.Info("PR exists and is create only")
-		return ResultPrOpen, prDetail, nil
+		return ResultPrOpen, prID, nil
 	}
 
-	if prID != nil && repo.IsPullRequestOpen(prID) {
-		if prDetail != nil {
-			ctx = context.WithValue(ctx, sbcontext.PullRequestKey{}, *prDetail)
-		}
+	if prID != nil && prID.State == host.PullRequestStateOpen {
+		ctx = context.WithValue(ctx, sbcontext.PullRequestKey{}, *prID)
 
-		if task.AutoCloseAfter > 0 && prDetail != nil && prDetail.CreatedAt != nil {
+		if task.AutoCloseAfter > 0 && !prID.CreatedAt.IsZero() {
 			dur := time.Duration(task.AutoCloseAfter) * time.Second
-			if time.Now().After(prDetail.CreatedAt.Add(dur)) {
+			if time.Now().After(prID.CreatedAt.Add(dur)) {
 				logger.Info("Auto-closing pull request")
 				if !dryRun {
 					msg := fmt.Sprintf("Pull request has been open for longer than %s. Closing automatically.", dur.String())
 					err := repo.ClosePullRequest(msg, prID)
 					if err != nil {
-						return ResultUnknown, prDetail, fmt.Errorf("auto-close pull request: %w", err)
+						return ResultUnknown, prID, fmt.Errorf("auto-close pull request: %w", err)
 					}
 				}
 
-				return ResultPrClosed, prDetail, nil
+				return ResultPrClosed, prID, nil
 			}
 		}
 	}
@@ -347,7 +344,7 @@ func applyTaskToRepository(ctx context.Context, dryRun bool, gitc git.GitClient,
 		if !dryRun {
 			err := host.DeletePullRequestCommentByIdentifier("branch-modified", prID, repo)
 			if err != nil {
-				return ResultUnknown, prDetail, err
+				return ResultUnknown, prID, err
 			}
 		}
 	}
@@ -355,72 +352,72 @@ func applyTaskToRepository(ctx context.Context, dryRun bool, gitc git.GitClient,
 	// If no PR is currently open, always force-rebase.
 	// This ensures that commits made by users to a
 	// branch created by previous runs get removed.
-	if prID != nil && !repo.IsPullRequestOpen(prID) {
+	if prID != nil && prID.State != host.PullRequestStateOpen {
 		forceRebase = true
 	}
 
 	hasConflict, err := gitc.UpdateTaskBranch(branchName, forceRebase, repo)
 	if err != nil {
 		var branchModifiedErr *git.BranchModifiedError
-		if errors.As(err, &branchModifiedErr) && prID != nil && repo.IsPullRequestOpen(prID) {
+		if errors.As(err, &branchModifiedErr) && prID != nil && prID.State == host.PullRequestStateOpen {
 			logger.Warn("Branch contains commits not made by saturn-bot")
 			body, err := template.RenderBranchModified(template.BranchModifiedInput{
 				Checksums:     branchModifiedErr.Checksums,
 				DefaultBranch: repo.BaseBranch(),
 			})
 			if err != nil {
-				return ResultUnknown, prDetail, err
+				return ResultUnknown, prID, err
 			}
 
 			logger.Debug("Creating pull request comment because the branch was modified")
 			if !dryRun {
 				err := host.CreatePullRequestCommentWithIdentifier(body, "branch-modified", prID, repo)
 				if err != nil {
-					return ResultUnknown, prDetail, fmt.Errorf("create comment on merge request: %w", err)
+					return ResultUnknown, prID, fmt.Errorf("create comment on merge request: %w", err)
 				}
 			}
 
-			return ResultBranchModified, prDetail, nil
+			return ResultBranchModified, prID, nil
 		}
 
 		var emptyErr git.EmptyRepositoryError
 		if errors.Is(err, emptyErr) {
 			logger.Debug("Repository is empty")
-			return ResultNoMatch, prDetail, nil
+			return ResultNoMatch, prID, nil
 		}
 
-		return ResultUnknown, prDetail, fmt.Errorf("update of git branch of task failed: %w", err)
+		return ResultUnknown, prID, fmt.Errorf("update of git branch of task failed: %w", err)
 	}
 
 	err = applyActionsInDirectory(task.Actions(), ctx, workDir)
 	if err != nil {
-		return ResultUnknown, prDetail, err
+		return ResultUnknown, prID, err
 	}
 
 	hasLocalChanges, err := gitc.HasLocalChanges()
 	if err != nil {
-		return ResultUnknown, prDetail, fmt.Errorf("check for local changes failed: %w", err)
+		return ResultUnknown, prID, fmt.Errorf("check for local changes failed: %w", err)
 	}
 
 	if hasLocalChanges {
 		commitMsg := task.CommitMessage
 		err := gitc.CommitChanges(commitMsg)
 		if err != nil {
-			return ResultUnknown, prDetail, fmt.Errorf("committing changes failed: %w", err)
+			return ResultUnknown, prID, fmt.Errorf("committing changes failed: %w", err)
 		}
 	}
 
 	hasChangesInRemoteDefaultBranch, err := gitc.HasRemoteChanges(repo.BaseBranch())
 	if err != nil {
-		return ResultUnknown, prDetail, fmt.Errorf("check for remote changes in default branch failed: %w", err)
+		return ResultUnknown, prID, fmt.Errorf("check for remote changes in default branch failed: %w", err)
 	}
 
-	if !hasChangesInRemoteDefaultBranch && prID != nil && repo.IsPullRequestOpen(prID) {
+	if !hasChangesInRemoteDefaultBranch && prID != nil && prID.State == host.PullRequestStateOpen {
 		logger.Info("Closing pull request because base branch contains all changes")
 		if !dryRun {
 			err := repo.ClosePullRequest("Everything up-to-date. Closing.", prID)
 			if err != nil {
-				return ResultUnknown, prDetail, fmt.Errorf("close pull request: %w", err)
+				return ResultUnknown, prID, fmt.Errorf("close pull request: %w", err)
 			}
 		}
 
@@ -428,21 +425,21 @@ func applyTaskToRepository(ctx context.Context, dryRun bool, gitc git.GitClient,
 		if !dryRun {
 			err := repo.DeleteBranch(prID)
 			if err != nil {
-				return ResultUnknown, prDetail, fmt.Errorf("delete branch: %w", err)
+				return ResultUnknown, prID, fmt.Errorf("delete branch: %w", err)
 			}
 		}
 
 		err = task.OnPrClosed(ctx)
 		if err != nil {
-			return ResultUnknown, prDetail, fmt.Errorf("pr closed event failed: %w", err)
+			return ResultUnknown, prID, fmt.Errorf("pr closed event failed: %w", err)
 		}
 
-		return ResultPrClosed, prDetail, nil
+		return ResultPrClosed, prID, nil
 	}
 
 	hasRemoteChanges, err := gitc.HasRemoteChanges(branchName)
 	if err != nil {
-		return ResultUnknown, prDetail, fmt.Errorf("check for remote changes failed: %w", err)
+		return ResultUnknown, prID, fmt.Errorf("check for remote changes failed: %w", err)
 	}
 
 	hasChanges := (hasLocalChanges && hasRemoteChanges) || hasConflict
@@ -451,7 +448,7 @@ func applyTaskToRepository(ctx context.Context, dryRun bool, gitc git.GitClient,
 		if !dryRun {
 			err := gitc.Push(branchName, true)
 			if err != nil {
-				return ResultUnknown, prDetail, fmt.Errorf("push failed: %w", err)
+				return ResultUnknown, prID, fmt.Errorf("push failed: %w", err)
 			}
 		}
 	} else {
@@ -461,7 +458,7 @@ func applyTaskToRepository(ctx context.Context, dryRun bool, gitc git.GitClient,
 	ctx = updateTemplateVars(ctx, repo, task)
 	prTitle, err := task.RenderPrTitle(template.FromContext(ctx))
 	if err != nil {
-		return ResultUnknown, prDetail, err
+		return ResultUnknown, prID, err
 	}
 
 	prData := host.PullRequestData{
@@ -479,82 +476,82 @@ func applyTaskToRepository(ctx context.Context, dryRun bool, gitc git.GitClient,
 
 	// Always create if branch of task contains changes compared to default branch and no PR has been created yet.
 	// Create if branch of task contains changes and the PR has been merged or closed before.
-	if (hasChangesInRemoteDefaultBranch && prID == nil) || (hasChanges && (prID == nil || repo.IsPullRequestMerged(prID) || repo.IsPullRequestClosed(prID))) {
+	if (hasChangesInRemoteDefaultBranch && prID == nil) || (hasChanges && (prID == nil || prID.State == host.PullRequestStateMerged || prID.State == host.PullRequestStateClosed)) {
 		logger.Info("Creating pull request")
 		if !dryRun {
-			prDetail, err = repo.CreatePullRequest(branchName, prData)
+			prID, err = repo.CreatePullRequest(branchName, prData)
 			if err != nil {
-				return ResultUnknown, prDetail, fmt.Errorf("failed to create pull request: %w", err)
+				return ResultUnknown, prID, fmt.Errorf("failed to create pull request: %w", err)
 			}
 		}
 
 		err = task.OnPrCreated(ctx)
 		if err != nil {
-			return ResultUnknown, prDetail, fmt.Errorf("pr created event failed: %w", err)
+			return ResultUnknown, prID, fmt.Errorf("pr created event failed: %w", err)
 		}
 
-		return ResultPrCreated, prDetail, nil
+		return ResultPrCreated, prID, nil
 	}
 
 	// Try to merge if auto-merge is enabled, no new changes have been detected and the pull request is open
-	if task.AutoMerge && !hasChanges && prID != nil && repo.IsPullRequestOpen(prID) {
+	if task.AutoMerge && !hasChanges && prID != nil && prID.State == host.PullRequestStateOpen {
 		success, err := repo.HasSuccessfulPullRequestBuild(prID)
 		if err != nil {
-			return ResultUnknown, prDetail, fmt.Errorf("check for successful pull request build failed: %w", err)
+			return ResultUnknown, prID, fmt.Errorf("check for successful pull request build failed: %w", err)
 		}
 
 		if !success {
-			return ResultChecksFailed, prDetail, nil
+			return ResultChecksFailed, prID, nil
 		}
 
-		if !canMergeAfter(repo.GetPullRequestCreationTime(prID), task.CalcAutoMergeAfter()) {
+		if !canMergeAfter(prID.CreatedAt, task.CalcAutoMergeAfter()) {
 			logger.Info("Too early to merge pull request")
-			return ResultAutoMergeTooEarly, prDetail, nil
+			return ResultAutoMergeTooEarly, prID, nil
 		}
 
 		canMerge, err := repo.CanMergePullRequest(prID)
 		if err != nil {
-			return ResultUnknown, prDetail, fmt.Errorf("check if pull request can be merged: %w", err)
+			return ResultUnknown, prID, fmt.Errorf("check if pull request can be merged: %w", err)
 		}
 
 		if !canMerge {
 			logger.Warn("Cannot merge pull request")
-			return ResultConflict, prDetail, nil
+			return ResultConflict, prID, nil
 		}
 
 		logger.Info("Merging pull request")
 		if !dryRun {
 			err := repo.MergePullRequest(!task.KeepBranchAfterMerge, prID)
 			if err != nil {
-				return ResultUnknown, prDetail, fmt.Errorf("failed to merge pull request: %w", err)
+				return ResultUnknown, prID, fmt.Errorf("failed to merge pull request: %w", err)
 			}
 		}
 
 		err = task.OnPrMerged(ctx)
 		if err != nil {
-			return ResultUnknown, prDetail, fmt.Errorf("pr merged event failed: %w", err)
+			return ResultUnknown, prID, fmt.Errorf("pr merged event failed: %w", err)
 		}
 
-		prDetail.State = host.PullRequestStateMerged
-		return ResultPrMerged, prDetail, nil
+		prID.State = host.PullRequestStateMerged
+		return ResultPrMerged, prID, nil
 	}
 
-	if prID != nil && repo.IsPullRequestOpen(prID) {
+	if prID != nil && prID.State == host.PullRequestStateOpen {
 		logger.Debug("Updating pull request")
 		if !dryRun {
 			err := repo.UpdatePullRequest(prData, prID)
 			if err != nil {
-				return ResultUnknown, prDetail, fmt.Errorf("failed to update pull request: %w", err)
+				return ResultUnknown, prID, fmt.Errorf("failed to update pull request: %w", err)
 			}
 		}
 
-		return ResultPrOpen, prDetail, nil
+		return ResultPrOpen, prID, nil
 	}
 
-	return ResultNoChanges, prDetail, nil
+	return ResultNoChanges, prID, nil
 }
 
-func needsRebaseByUser(repo host.Repository, pr any) bool {
+func needsRebaseByUser(repo host.Repository, pr *host.PullRequest) bool {
 	body := repo.GetPullRequestBody(pr)
 	return strings.Contains(body, "[x] If you want to rebase this PR")
 }
@@ -657,7 +654,7 @@ func IsPrOpen(result Result) bool {
 		return true
 	case ResultConflict:
 		return true
+	default:
+		return false
 	}
-
-	return false
 }

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -462,19 +462,14 @@ func TestProcessor_Process_UpdatePullRequest(t *testing.T) {
 	assert.Equal(t, prID, results[0].PullRequest)
 }
 
-// TODO: check test
 func TestProcessor_Process_NoChanges(t *testing.T) {
 	tempDir := t.TempDir()
-	prID := &host.PullRequest{State: host.PullRequestStateOpen}
+	prID := &host.PullRequest{State: host.PullRequestStateMerged}
 	ctrl := gomock.NewController(t)
 	repo := setupRepoMock(ctrl)
 	repo.EXPECT().FindPullRequest("saturn-bot--unittest").Return(prID, nil)
-	//repo.EXPECT().PullRequest(prID).Return(nil).AnyTimes()
-	//repo.EXPECT().IsPullRequestClosed(prID).Return(false).AnyTimes()
-	//repo.EXPECT().IsPullRequestMerged(prID).Return(false).AnyTimes()
 	repo.EXPECT().GetPullRequestBody(prID).Return("")
 	repo.EXPECT().BaseBranch().Return("main")
-	//repo.EXPECT().IsPullRequestOpen(prID).Return(false).AnyTimes()
 	gitc := gitmock.NewMockGitClient(ctrl)
 	gitc.EXPECT().Prepare(repo, false).Return(tempDir, nil)
 	gitc.EXPECT().UpdateTaskBranch("saturn-bot--unittest", true, repo)

--- a/test/mock/host/host.gen.go
+++ b/test/mock/host/host.gen.go
@@ -57,7 +57,7 @@ func (mr *MockRepositoryMockRecorder) BaseBranch() *gomock.Call {
 }
 
 // CanMergePullRequest mocks base method.
-func (m *MockRepository) CanMergePullRequest(pr any) (bool, error) {
+func (m *MockRepository) CanMergePullRequest(pr *host.PullRequest) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanMergePullRequest", pr)
 	ret0, _ := ret[0].(bool)
@@ -100,7 +100,7 @@ func (mr *MockRepositoryMockRecorder) CloneUrlSsh() *gomock.Call {
 }
 
 // ClosePullRequest mocks base method.
-func (m *MockRepository) ClosePullRequest(msg string, pr any) error {
+func (m *MockRepository) ClosePullRequest(msg string, pr *host.PullRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClosePullRequest", msg, pr)
 	ret0, _ := ret[0].(error)
@@ -129,7 +129,7 @@ func (mr *MockRepositoryMockRecorder) CreatePullRequest(branch, data any) *gomoc
 }
 
 // CreatePullRequestComment mocks base method.
-func (m *MockRepository) CreatePullRequestComment(body string, pr any) error {
+func (m *MockRepository) CreatePullRequestComment(body string, pr *host.PullRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePullRequestComment", body, pr)
 	ret0, _ := ret[0].(error)
@@ -143,7 +143,7 @@ func (mr *MockRepositoryMockRecorder) CreatePullRequestComment(body, pr any) *go
 }
 
 // DeleteBranch mocks base method.
-func (m *MockRepository) DeleteBranch(pr any) error {
+func (m *MockRepository) DeleteBranch(pr *host.PullRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteBranch", pr)
 	ret0, _ := ret[0].(error)
@@ -157,7 +157,7 @@ func (mr *MockRepositoryMockRecorder) DeleteBranch(pr any) *gomock.Call {
 }
 
 // DeletePullRequestComment mocks base method.
-func (m *MockRepository) DeletePullRequestComment(comment host.PullRequestComment, pr any) error {
+func (m *MockRepository) DeletePullRequestComment(comment host.PullRequestComment, pr *host.PullRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePullRequestComment", comment, pr)
 	ret0, _ := ret[0].(error)
@@ -171,10 +171,10 @@ func (mr *MockRepositoryMockRecorder) DeletePullRequestComment(comment, pr any) 
 }
 
 // FindPullRequest mocks base method.
-func (m *MockRepository) FindPullRequest(branch string) (any, error) {
+func (m *MockRepository) FindPullRequest(branch string) (*host.PullRequest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindPullRequest", branch)
-	ret0, _ := ret[0].(any)
+	ret0, _ := ret[0].(*host.PullRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -200,7 +200,7 @@ func (mr *MockRepositoryMockRecorder) FullName() *gomock.Call {
 }
 
 // GetPullRequestBody mocks base method.
-func (m *MockRepository) GetPullRequestBody(pr any) string {
+func (m *MockRepository) GetPullRequestBody(pr *host.PullRequest) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPullRequestBody", pr)
 	ret0, _ := ret[0].(string)
@@ -213,22 +213,8 @@ func (mr *MockRepositoryMockRecorder) GetPullRequestBody(pr any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPullRequestBody", reflect.TypeOf((*MockRepository)(nil).GetPullRequestBody), pr)
 }
 
-// GetPullRequestCreationTime mocks base method.
-func (m *MockRepository) GetPullRequestCreationTime(pr any) time.Time {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPullRequestCreationTime", pr)
-	ret0, _ := ret[0].(time.Time)
-	return ret0
-}
-
-// GetPullRequestCreationTime indicates an expected call of GetPullRequestCreationTime.
-func (mr *MockRepositoryMockRecorder) GetPullRequestCreationTime(pr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPullRequestCreationTime", reflect.TypeOf((*MockRepository)(nil).GetPullRequestCreationTime), pr)
-}
-
 // HasSuccessfulPullRequestBuild mocks base method.
-func (m *MockRepository) HasSuccessfulPullRequestBuild(pr any) (bool, error) {
+func (m *MockRepository) HasSuccessfulPullRequestBuild(pr *host.PullRequest) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasSuccessfulPullRequestBuild", pr)
 	ret0, _ := ret[0].(bool)
@@ -284,50 +270,8 @@ func (mr *MockRepositoryMockRecorder) IsArchived() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsArchived", reflect.TypeOf((*MockRepository)(nil).IsArchived))
 }
 
-// IsPullRequestClosed mocks base method.
-func (m *MockRepository) IsPullRequestClosed(pr any) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPullRequestClosed", pr)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPullRequestClosed indicates an expected call of IsPullRequestClosed.
-func (mr *MockRepositoryMockRecorder) IsPullRequestClosed(pr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPullRequestClosed", reflect.TypeOf((*MockRepository)(nil).IsPullRequestClosed), pr)
-}
-
-// IsPullRequestMerged mocks base method.
-func (m *MockRepository) IsPullRequestMerged(pr any) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPullRequestMerged", pr)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPullRequestMerged indicates an expected call of IsPullRequestMerged.
-func (mr *MockRepositoryMockRecorder) IsPullRequestMerged(pr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPullRequestMerged", reflect.TypeOf((*MockRepository)(nil).IsPullRequestMerged), pr)
-}
-
-// IsPullRequestOpen mocks base method.
-func (m *MockRepository) IsPullRequestOpen(pr any) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsPullRequestOpen", pr)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsPullRequestOpen indicates an expected call of IsPullRequestOpen.
-func (mr *MockRepositoryMockRecorder) IsPullRequestOpen(pr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPullRequestOpen", reflect.TypeOf((*MockRepository)(nil).IsPullRequestOpen), pr)
-}
-
 // ListPullRequestComments mocks base method.
-func (m *MockRepository) ListPullRequestComments(pr any) ([]host.PullRequestComment, error) {
+func (m *MockRepository) ListPullRequestComments(pr *host.PullRequest) ([]host.PullRequestComment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPullRequestComments", pr)
 	ret0, _ := ret[0].([]host.PullRequestComment)
@@ -342,7 +286,7 @@ func (mr *MockRepositoryMockRecorder) ListPullRequestComments(pr any) *gomock.Ca
 }
 
 // MergePullRequest mocks base method.
-func (m *MockRepository) MergePullRequest(deleteBranch bool, pr any) error {
+func (m *MockRepository) MergePullRequest(deleteBranch bool, pr *host.PullRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MergePullRequest", deleteBranch, pr)
 	ret0, _ := ret[0].(error)
@@ -383,20 +327,6 @@ func (mr *MockRepositoryMockRecorder) Owner() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Owner", reflect.TypeOf((*MockRepository)(nil).Owner))
 }
 
-// PullRequest mocks base method.
-func (m *MockRepository) PullRequest(pr any) *host.PullRequest {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PullRequest", pr)
-	ret0, _ := ret[0].(*host.PullRequest)
-	return ret0
-}
-
-// PullRequest indicates an expected call of PullRequest.
-func (mr *MockRepositoryMockRecorder) PullRequest(pr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullRequest", reflect.TypeOf((*MockRepository)(nil).PullRequest), pr)
-}
-
 // Raw mocks base method.
 func (m *MockRepository) Raw() any {
 	m.ctrl.T.Helper()
@@ -412,7 +342,7 @@ func (mr *MockRepositoryMockRecorder) Raw() *gomock.Call {
 }
 
 // UpdatePullRequest mocks base method.
-func (m *MockRepository) UpdatePullRequest(data host.PullRequestData, pr any) error {
+func (m *MockRepository) UpdatePullRequest(data host.PullRequestData, pr *host.PullRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePullRequest", data, pr)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
Before this change, methods of the `Repository` interface returned `any`.
`any` has proven to be too generic and hard to work with.
This change is done to prepare the code base for caching of pull requests.

- Update interface `Repository` to return or accept `PullRequest` instead of any.
- Update implementations of `Repository`.
- Adjust dependent code.
- Update tests.