### PR TITLE
refactor: Remove funcs from Options struct

### DIFF
--- a/pkg/command/run.go
+++ b/pkg/command/run.go
@@ -141,15 +141,15 @@ func ExecuteRun(opts options.Opts, repositoryNames, taskFiles []string, inputs m
 
 	repositoryFileCache := &host.RepositoryFileCache{
 		Clock: clock.Default,
-		Dir:   filepath.Join(opts.DataDir(), "cache"),
-		Ttl:   opts.RepositoryCacheTtl(),
+		Dir:   filepath.Join(opts.DataDir, "cache"),
+		Ttl:   opts.RepositoryCacheTtl,
 	}
 
 	e := &Run{
 		DryRun: opts.Config.DryRun,
 		Hosts:  opts.Hosts,
 		Processor: &processor.Processor{
-			DataDir: opts.DataDir(),
+			DataDir: opts.DataDir,
 			Git:     gitClient,
 		},
 		PushGateway:      opts.PushGateway,

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -92,7 +92,7 @@ func New(opts options.Opts) (*Git, error) {
 
 		clock:            opts.Clock,
 		cloneOpts:        opts.Config.GitCloneOptions,
-		dataDir:          opts.DataDir(),
+		dataDir:          opts.DataDir,
 		defaultCommitMsg: opts.Config.GitCommitMessage,
 		EnvVars:          envVars,
 		CmdExec:          execCmd,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -54,6 +54,7 @@ type Opts struct {
 	// Defaults to an object that proxies to the [time] package.
 	Clock                clock.Clock
 	Config               config.Configuration
+	DataDir              string
 	FilterFactories      FilterFactories
 	Hosts                []host.Host
 	IsCi                 bool
@@ -61,27 +62,13 @@ type Opts struct {
 	PushGateway          *push.Pusher
 	PrometheusGatherer   prometheus.Gatherer
 	PrometheusRegisterer prometheus.Registerer
-
-	dataDir            string
-	repositoryCacheTtl time.Duration
-	workerLoopInterval time.Duration
-}
-
-func (o Opts) DataDir() string {
-	return o.dataDir
-}
-
-func (o *Opts) RepositoryCacheTtl() time.Duration {
-	return o.repositoryCacheTtl
+	RepositoryCacheTtl   time.Duration
+	WorkerLoopInterval   time.Duration
 }
 
 func (o *Opts) SetPrometheusRegistry(reg *prometheus.Registry) {
 	o.PrometheusGatherer = reg
 	o.PrometheusRegisterer = reg
-}
-
-func (o Opts) WorkerLoopInterval() time.Duration {
-	return o.workerLoopInterval
 }
 
 // ToOptions takes a configuration struct, initializes global state
@@ -171,19 +158,19 @@ func Initialize(opts *Opts) error {
 		return fmt.Errorf("data directory %s is not a directory", dataDir)
 	}
 
-	opts.dataDir = dataDir
+	opts.DataDir = dataDir
 
 	loop, err := time.ParseDuration(opts.Config.WorkerLoopInterval)
 	if err != nil {
 		return fmt.Errorf("setting workerLoopInterval '%s' is not a Go duration: %w", opts.Config.WorkerLoopInterval, err)
 	}
-	opts.workerLoopInterval = loop
+	opts.WorkerLoopInterval = loop
 
 	repositoryCacheTtl, err := time.ParseDuration(opts.Config.RepositoryCacheTtl)
 	if err != nil {
 		return fmt.Errorf("setting repositoryCacheTtl '%s' is not a Go duration: %w", opts.Config.RepositoryCacheTtl, err)
 	}
-	opts.repositoryCacheTtl = repositoryCacheTtl
+	opts.RepositoryCacheTtl = repositoryCacheTtl
 
 	if opts.Config.PrometheusPushgatewayUrl != nil && opts.PrometheusRegisterer != nil && opts.PrometheusGatherer != nil {
 		metrics.Register(opts.PrometheusRegisterer)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,7 +49,7 @@ func (s *Server) Start(opts options.Opts, taskPaths []string) error {
 
 	dbPath := opts.Config.ServerDatabasePath
 	if dbPath == "" {
-		dbPath = filepath.Join(opts.DataDir(), "db", "saturn-bot.db")
+		dbPath = filepath.Join(opts.DataDir, "db", "saturn-bot.db")
 	}
 
 	database, err := sbdb.New(opts.Config.ServerDatabaseLog, dbPath, sbdb.Migrate(db.Migrations()))

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -168,7 +168,7 @@ func (w *Worker) Start() {
 	w.startHttpServer()
 	w.resultChan = make(chan Result, 1)
 	w.stopChan = make(chan chan struct{})
-	t := time.NewTicker(w.opts.WorkerLoopInterval())
+	t := time.NewTicker(w.opts.WorkerLoopInterval)
 	parallelExecutions := w.opts.Config.WorkerParallelExecutions
 	metricRunsMax.Set(float64(parallelExecutions))
 	executionCounter := 0


### PR DESCRIPTION
The functions don't offer much benefit. The struct usually doesn't get mocked in tests.

Makes it easier to work with the `Options` struct, especially in tests.