### PR TITLE
refactor(host): Use an iterator to list repositories

### DIFF
--- a/pkg/command/run_test.go
+++ b/pkg/command/run_test.go
@@ -40,10 +40,9 @@ type repoCacheItem struct {
 }
 
 type mockHost struct {
-	pullRequestIterator              host.PullRequestIterator
-	repositoryIterator               host.RepositoryIterator
-	repositories                     []host.Repository
-	repositoriesWithOpenPullRequests []host.Repository
+	pullRequestIterator host.PullRequestIterator
+	repositoryIterator  host.RepositoryIterator
+	repositories        []host.Repository
 }
 
 func (m *mockHost) CreateFromJson(dec *json.Decoder) (host.Repository, error) {

--- a/pkg/host/cache.go
+++ b/pkg/host/cache.go
@@ -199,7 +199,7 @@ func (rc *RepositoryFileCache) writeRepository(repo Repository) error {
 func (rc *RepositoryFileCache) updateCache(hosts []Host) error {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
-	wg := &sync.WaitGroup{}
+	var wg sync.WaitGroup
 	errChan := make(chan error, len(hosts))
 	for _, h := range hosts {
 		wg.Add(1)

--- a/pkg/host/cache.go
+++ b/pkg/host/cache.go
@@ -196,69 +196,58 @@ func (rc *RepositoryFileCache) writeRepository(repo Repository) error {
 	return nil
 }
 
-func (rc *RepositoryFileCache) receiveRepositories(expectedFinishes int, results chan []Repository, errChan chan error) error {
-	finishes := 0
-	for {
-		select {
-		case repoList := <-results:
-			for _, repo := range repoList {
-				if repo.IsArchived() {
-					_ = rc.remove(repo)
-					continue
-				}
-
-				err := rc.writeRepository(repo)
-				if err != nil {
-					return err
-				}
-			}
-
-		case err := <-errChan:
-			finishes += 1
-			if err != nil {
-				return err
-			}
-		}
-
-		if expectedFinishes == finishes {
-			return nil
-		}
-	}
-}
-
 func (rc *RepositoryFileCache) updateCache(hosts []Host) error {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
-	listRepos := make(chan []Repository)
-	listReposErrs := make(chan error)
-	start := rc.Clock.Now()
+	wg := &sync.WaitGroup{}
+	errChan := make(chan error, len(hosts))
 	for _, h := range hosts {
-		since, err := rc.readLastUpdateTimestamp(h)
-		if err != nil {
-			return err
-		}
-
-		if since == nil {
-			log.Log().Infof("Full update of repository cache for host %s", h.Name())
-			_ = os.RemoveAll(rc.Dir)
-		} else {
-			log.Log().Infof("Partial update of repository cache for host %s since %s", h.Name(), since)
-		}
-
-		go h.ListRepositories(since, listRepos, listReposErrs)
+		wg.Add(1)
+		go func() {
+			errChan <- rc.updateCacheForHost(h)
+			wg.Done()
+		}()
 	}
 
-	err := rc.receiveRepositories(len(hosts), listRepos, listReposErrs)
+	wg.Wait()
+	close(errChan)
+	var err error
+	for updateErr := range errChan {
+		err = errors.Join(err, updateErr)
+	}
+
+	return err
+}
+
+func (rc *RepositoryFileCache) updateCacheForHost(host Host) error {
+	since, err := rc.readLastUpdateTimestamp(host)
 	if err != nil {
 		return err
 	}
 
-	for _, h := range hosts {
-		err := rc.writeLastUpdateTimestamp(h, start)
-		if err != nil {
+	if since == nil {
+		log.Log().Infof("Full update of repository cache for host %s", host.Name())
+		_ = os.RemoveAll(rc.Dir)
+	} else {
+		log.Log().Infof("Partial update of repository cache for host %s since %s", host.Name(), since)
+	}
+
+	start := rc.Clock.Now()
+	repoIterator := host.RepositoryIterator()
+	for repo := range repoIterator.ListRepositories(since) {
+		if repo.IsArchived() {
+			_ = rc.remove(repo)
+			continue
+		}
+
+		if err := rc.writeRepository(repo); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	if err := repoIterator.Error(); err != nil {
+		return err
+	}
+
+	return rc.writeLastUpdateTimestamp(host, start)
 }

--- a/pkg/host/cache.go
+++ b/pkg/host/cache.go
@@ -227,7 +227,7 @@ func (rc *RepositoryFileCache) updateCacheForHost(host Host) error {
 
 	if since == nil {
 		log.Log().Infof("Full update of repository cache for host %s", host.Name())
-		_ = os.RemoveAll(rc.Dir)
+		_ = os.RemoveAll(filepath.Join(rc.Dir, host.Name()))
 	} else {
 		log.Log().Infof("Partial update of repository cache for host %s since %s", host.Name(), since)
 	}

--- a/pkg/host/cache.go
+++ b/pkg/host/cache.go
@@ -234,6 +234,7 @@ func (rc *RepositoryFileCache) updateCacheForHost(host Host) error {
 
 	start := rc.Clock.Now()
 	repoIterator := host.RepositoryIterator()
+	updateCounter := 0
 	for repo := range repoIterator.ListRepositories(since) {
 		if repo.IsArchived() {
 			_ = rc.remove(repo)
@@ -243,11 +244,14 @@ func (rc *RepositoryFileCache) updateCacheForHost(host Host) error {
 		if err := rc.writeRepository(repo); err != nil {
 			return err
 		}
+
+		updateCounter++
 	}
 
 	if err := repoIterator.Error(); err != nil {
 		return err
 	}
 
+	log.Log().Infof("Updated repository cache with %d new items for host %s", updateCounter, host.Name())
 	return rc.writeLastUpdateTimestamp(host, start)
 }

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -168,8 +168,7 @@ type Host interface {
 	CreateFromName(name string) (Repository, error)
 	// CreateFromJson takes a JSON decoder from which to unmarshal a Repository and return it.
 	CreateFromJson(dec *json.Decoder) (Repository, error)
-	ListRepositories(since *time.Time, result chan []Repository, errChan chan error)
-	ListRepositoriesWithOpenPullRequests(result chan []Repository, errChan chan error)
+	RepositoryIterator() RepositoryIterator
 	// PullRequestFactory return a [PullRequestFactory] that creates a new data struct of a pull request for the host.
 	PullRequestFactory() PullRequestFactory
 	// PullRequestIterator returns an implementation of [PullRequestIterator] to iterate over pull requests of the host.
@@ -185,6 +184,11 @@ type PullRequestIterator interface {
 	ListPullRequests(since *time.Time) iter.Seq[*PullRequest]
 	// Error returns an error that occurred during ListPullRequests.
 	// Callers of ListPullRequests should call this function after the iterator has returned to check if there was an error.
+	Error() error
+}
+
+type RepositoryIterator interface {
+	ListRepositories(since *time.Time) iter.Seq[Repository]
 	Error() error
 }
 

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -168,6 +168,7 @@ type Host interface {
 	CreateFromName(name string) (Repository, error)
 	// CreateFromJson takes a JSON decoder from which to unmarshal a Repository and return it.
 	CreateFromJson(dec *json.Decoder) (Repository, error)
+	// RepositoryIterator returns an implementation of [RepositoryIterator] to iterate over repositories of the host.
 	RepositoryIterator() RepositoryIterator
 	// PullRequestFactory return a [PullRequestFactory] that creates a new data struct of a pull request for the host.
 	PullRequestFactory() PullRequestFactory
@@ -187,8 +188,13 @@ type PullRequestIterator interface {
 	Error() error
 }
 
+// RepositoryIterator is an iterator to iterate over repositories in a host.
 type RepositoryIterator interface {
+	// ListRepositories returns an iter.Seq to iterate over repositories in a host.
+	// If since is not nil, the function should return only the repositories that have been updated since the given time.
 	ListRepositories(since *time.Time) iter.Seq[Repository]
+	// Error returns an error that occurred during ListRepositories.
+	// Callers of ListRepositories should call this function after the iterator has returned to check if there was an error.
 	Error() error
 }
 

--- a/test/mock/host/host.gen.go
+++ b/test/mock/host/host.gen.go
@@ -453,30 +453,6 @@ func (mr *MockHostMockRecorder) CreateFromName(name any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFromName", reflect.TypeOf((*MockHost)(nil).CreateFromName), name)
 }
 
-// ListRepositories mocks base method.
-func (m *MockHost) ListRepositories(since *time.Time, result chan []host.Repository, errChan chan error) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ListRepositories", since, result, errChan)
-}
-
-// ListRepositories indicates an expected call of ListRepositories.
-func (mr *MockHostMockRecorder) ListRepositories(since, result, errChan any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositories", reflect.TypeOf((*MockHost)(nil).ListRepositories), since, result, errChan)
-}
-
-// ListRepositoriesWithOpenPullRequests mocks base method.
-func (m *MockHost) ListRepositoriesWithOpenPullRequests(result chan []host.Repository, errChan chan error) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ListRepositoriesWithOpenPullRequests", result, errChan)
-}
-
-// ListRepositoriesWithOpenPullRequests indicates an expected call of ListRepositoriesWithOpenPullRequests.
-func (mr *MockHostMockRecorder) ListRepositoriesWithOpenPullRequests(result, errChan any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositoriesWithOpenPullRequests", reflect.TypeOf((*MockHost)(nil).ListRepositoriesWithOpenPullRequests), result, errChan)
-}
-
 // Name mocks base method.
 func (m *MockHost) Name() string {
 	m.ctrl.T.Helper()
@@ -517,6 +493,20 @@ func (m *MockHost) PullRequestIterator() host.PullRequestIterator {
 func (mr *MockHostMockRecorder) PullRequestIterator() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullRequestIterator", reflect.TypeOf((*MockHost)(nil).PullRequestIterator))
+}
+
+// RepositoryIterator mocks base method.
+func (m *MockHost) RepositoryIterator() host.RepositoryIterator {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RepositoryIterator")
+	ret0, _ := ret[0].(host.RepositoryIterator)
+	return ret0
+}
+
+// RepositoryIterator indicates an expected call of RepositoryIterator.
+func (mr *MockHostMockRecorder) RepositoryIterator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RepositoryIterator", reflect.TypeOf((*MockHost)(nil).RepositoryIterator))
 }
 
 // Type mocks base method.
@@ -583,6 +573,58 @@ func (m *MockPullRequestIterator) ListPullRequests(since *time.Time) iter.Seq[*h
 func (mr *MockPullRequestIteratorMockRecorder) ListPullRequests(since any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPullRequests", reflect.TypeOf((*MockPullRequestIterator)(nil).ListPullRequests), since)
+}
+
+// MockRepositoryIterator is a mock of RepositoryIterator interface.
+type MockRepositoryIterator struct {
+	ctrl     *gomock.Controller
+	recorder *MockRepositoryIteratorMockRecorder
+	isgomock struct{}
+}
+
+// MockRepositoryIteratorMockRecorder is the mock recorder for MockRepositoryIterator.
+type MockRepositoryIteratorMockRecorder struct {
+	mock *MockRepositoryIterator
+}
+
+// NewMockRepositoryIterator creates a new mock instance.
+func NewMockRepositoryIterator(ctrl *gomock.Controller) *MockRepositoryIterator {
+	mock := &MockRepositoryIterator{ctrl: ctrl}
+	mock.recorder = &MockRepositoryIteratorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRepositoryIterator) EXPECT() *MockRepositoryIteratorMockRecorder {
+	return m.recorder
+}
+
+// Error mocks base method.
+func (m *MockRepositoryIterator) Error() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Error")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Error indicates an expected call of Error.
+func (mr *MockRepositoryIteratorMockRecorder) Error() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockRepositoryIterator)(nil).Error))
+}
+
+// ListRepositories mocks base method.
+func (m *MockRepositoryIterator) ListRepositories(since *time.Time) iter.Seq[host.Repository] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRepositories", since)
+	ret0, _ := ret[0].(iter.Seq[host.Repository])
+	return ret0
+}
+
+// ListRepositories indicates an expected call of ListRepositories.
+func (mr *MockRepositoryIteratorMockRecorder) ListRepositories(since any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRepositories", reflect.TypeOf((*MockRepositoryIterator)(nil).ListRepositories), since)
 }
 
 // MockHostDetail is a mock of HostDetail interface.


### PR DESCRIPTION
Previous implementation used channels to compensate for the lack of iterators.
The use of an iterator makes it more obvious what the code is supposed to do.
Ranging over results also becomes easier.