### PR TITLE
feat(processor): Do not auto-close skipped pull requests

### DIFF
--- a/pkg/host/github_test.go
+++ b/pkg/host/github_test.go
@@ -105,15 +105,19 @@ func TestGitHubRepository_ClosePullRequest(t *testing.T) {
 			"state": "closed",
 		}).
 		Reply(200).
-		JSON(map[string]string{})
+		JSON(github.PullRequest{
+			Number: github.Ptr(987),
+			State:  github.Ptr("closed"),
+		})
 
 	repo := &GitHubRepository{
 		client: setupGitHubTestClient(),
 		repo:   setupGitHubRepository(),
 	}
-	err := repo.ClosePullRequest("close pull request", toSbPr(pr))
+	prUpdated, err := repo.ClosePullRequest("close pull request", toSbPr(pr))
 
 	require.NoError(t, err)
+	require.Equal(t, PullRequestStateClosed, prUpdated.State)
 	require.True(t, gock.IsDone())
 }
 

--- a/pkg/host/gitlab_test.go
+++ b/pkg/host/gitlab_test.go
@@ -73,14 +73,22 @@ func TestGitLabRepository_ClosePullRequest(t *testing.T) {
 		MatchType("json").
 		JSON(map[string]string{"state_event": "close"}).
 		Reply(200).
-		JSON(map[string]string{})
+		JSON(gitlab.MergeRequest{
+			CreatedAt:    ptr.To(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)),
+			IID:          987,
+			SourceBranch: "saturn-bot--unit-test",
+			State:        "closed",
+			WebURL:       "http://gitlab.local/unit/test/-/merge_requests/1",
+		})
 	project := &gitlab.Project{ID: 123}
 	mr := &gitlab.MergeRequest{IID: 987}
 
 	underTest := &GitLabRepository{client: setupClient(), project: project}
 
-	err := underTest.ClosePullRequest("Unit Test", toSbPr(mr))
+	prUpdated, err := underTest.ClosePullRequest("Unit Test", toSbPr(mr))
+
 	require.NoError(t, err)
+	require.Equal(t, PullRequestStateClosed, prUpdated.State)
 	require.True(t, gock.IsDone())
 }
 

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -127,7 +127,7 @@ type Repository interface {
 	CanMergePullRequest(pr *PullRequest) (bool, error)
 	CloneUrlHttp() string
 	CloneUrlSsh() string
-	ClosePullRequest(msg string, pr *PullRequest) error
+	ClosePullRequest(msg string, pr *PullRequest) (*PullRequest, error)
 	CreatePullRequestComment(body string, pr *PullRequest) error
 	CreatePullRequest(branch string, data PullRequestData) (*PullRequest, error)
 	DeleteBranch(pr *PullRequest) error

--- a/test/mock/host/host.gen.go
+++ b/test/mock/host/host.gen.go
@@ -101,11 +101,12 @@ func (mr *MockRepositoryMockRecorder) CloneUrlSsh() *gomock.Call {
 }
 
 // ClosePullRequest mocks base method.
-func (m *MockRepository) ClosePullRequest(msg string, pr *host.PullRequest) error {
+func (m *MockRepository) ClosePullRequest(msg string, pr *host.PullRequest) (*host.PullRequest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ClosePullRequest", msg, pr)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*host.PullRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // ClosePullRequest indicates an expected call of ClosePullRequest.


### PR DESCRIPTION
#185 added logic that results in saturn-bot closing pull requests that were skipped because a Task defines `changeLimit` or `maxOpenPRs`.

This change ensures that only pull requests are closed if the repository doesn't match a task.