### PR TITLE
feat(server): Wait for workers to report before shutting down

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -322,6 +322,22 @@ Labels specified here are merged with the [labels of a task](./task/index.md#lab
 | Env Var | `SATURN_BOT_SERVERDATABASEPATH` |
 | Type    | `string`                        |
 
+## serverShutdownTimeout
+
+[json-path:../../pkg/config/config.schema.json:$.properties.serverShutdownTimeout.description]
+
+!!! note
+
+    When running the server component in Kubernetes, set `terminationGracePeriodSeconds` of
+    the [PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podspec-v1-core)
+    to a value slightly higher than this value.
+
+| Name    | Value                              |
+|---------|------------------------------------|
+| Default | `5m`                               |
+| Env Var | `SATURN_BOT_SERVERSHUTDOWNTIMEOUT` |
+| Type    | `string`                           |
+
 ## serverWebhookSecretGithub
 
 [json-path:../../pkg/config/config.schema.json:$.properties.serverWebhookSecretGithub.description]

--- a/pkg/command/ci_test.go
+++ b/pkg/command/ci_test.go
@@ -35,7 +35,7 @@ func TestCiRunner_Run_Valid(t *testing.T) {
 	validFile.Close()
 
 	runner, err := command.NewCiRunner(options.Opts{
-		Config: config.Configuration{RepositoryCacheTtl: "6h", WorkerLoopInterval: "1m"},
+		Config: config.Configuration{RepositoryCacheTtl: "6h", ServerShutdownTimeout: "5m", WorkerLoopInterval: "1m"},
 	})
 	require.NoError(t, err)
 
@@ -60,7 +60,7 @@ func TestCiRunner_Run_Invalid(t *testing.T) {
 	invalidFile.Close()
 
 	runner, err := command.NewCiRunner(options.Opts{
-		Config: config.Configuration{RepositoryCacheTtl: "6h", WorkerLoopInterval: "1m"},
+		Config: config.Configuration{RepositoryCacheTtl: "6h", ServerShutdownTimeout: "5m", WorkerLoopInterval: "1m"},
 	})
 	require.NoError(t, err)
 

--- a/pkg/config/config.schema.json
+++ b/pkg/config/config.schema.json
@@ -173,7 +173,7 @@
     },
     "serverShutdownTimeout": {
       "default": "5m",
-      "description": "Duration to wait for runs to finish on shutdown before stopping the server.",
+      "description": "Duration to wait for active runs to finish before stopping the server.",
       "type": "string"
     },
     "workerLoopInterval": {

--- a/pkg/config/config.schema.json
+++ b/pkg/config/config.schema.json
@@ -171,6 +171,11 @@
       "description": "If `true`, serves the user interface.",
       "type": "boolean"
     },
+    "serverShutdownTimeout": {
+      "default": "5m",
+      "description": "Duration to wait for runs to finish on shutdown before stopping the server.",
+      "type": "string"
+    },
     "workerLoopInterval": {
       "default": "10s",
       "description": "Interval at which a worker queries the server to receive new tasks to execute.",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,6 +41,7 @@ func TestReadConfig(t *testing.T) {
 				ServerBaseUrl:            "http://localhost:3035",
 				ServerCompress:           true,
 				ServerServeUi:            true,
+				ServerShutdownTimeout:    "5m",
 				WorkerLoopInterval:       "10s",
 				WorkerParallelExecutions: 1,
 				WorkerServerAPIBaseURL:   "http://localhost:3035",

--- a/pkg/config/schema.gen.go
+++ b/pkg/config/schema.gen.go
@@ -113,6 +113,9 @@ type Configuration struct {
 	// If `true`, serves the user interface.
 	ServerServeUi bool `json:"serverServeUi,omitempty" yaml:"serverServeUi,omitempty" mapstructure:"serverServeUi,omitempty"`
 
+	// Duration to wait for runs to finish on shutdown before stopping the server.
+	ServerShutdownTimeout string `json:"serverShutdownTimeout,omitempty" yaml:"serverShutdownTimeout,omitempty" mapstructure:"serverShutdownTimeout,omitempty"`
+
 	// Secret to authenticate webhook requests sent by GitHub.
 	ServerWebhookSecretGithub string `json:"serverWebhookSecretGithub,omitempty" yaml:"serverWebhookSecretGithub,omitempty" mapstructure:"serverWebhookSecretGithub,omitempty"`
 
@@ -484,6 +487,9 @@ func (j *Configuration) UnmarshalJSON(b []byte) error {
 	if v, ok := raw["serverServeUi"]; !ok || v == nil {
 		plain.ServerServeUi = true
 	}
+	if v, ok := raw["serverShutdownTimeout"]; !ok || v == nil {
+		plain.ServerShutdownTimeout = "5m"
+	}
 	if v, ok := raw["serverWebhookSecretGithub"]; !ok || v == nil {
 		plain.ServerWebhookSecretGithub = ""
 	}
@@ -591,6 +597,9 @@ func (j *Configuration) UnmarshalYAML(value *yaml.Node) error {
 	}
 	if v, ok := raw["serverServeUi"]; !ok || v == nil {
 		plain.ServerServeUi = true
+	}
+	if v, ok := raw["serverShutdownTimeout"]; !ok || v == nil {
+		plain.ServerShutdownTimeout = "5m"
 	}
 	if v, ok := raw["serverWebhookSecretGithub"]; !ok || v == nil {
 		plain.ServerWebhookSecretGithub = ""

--- a/pkg/config/schema.gen.go
+++ b/pkg/config/schema.gen.go
@@ -113,7 +113,7 @@ type Configuration struct {
 	// If `true`, serves the user interface.
 	ServerServeUi bool `json:"serverServeUi,omitempty" yaml:"serverServeUi,omitempty" mapstructure:"serverServeUi,omitempty"`
 
-	// Duration to wait for runs to finish on shutdown before stopping the server.
+	// Duration to wait for active runs to finish before stopping the server.
 	ServerShutdownTimeout string `json:"serverShutdownTimeout,omitempty" yaml:"serverShutdownTimeout,omitempty" mapstructure:"serverShutdownTimeout,omitempty"`
 
 	// Secret to authenticate webhook requests sent by GitHub.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -65,6 +65,7 @@ type Opts struct {
 	RepositoryCacheTtl   time.Duration
 	// ServerShutdownCheckInterval is the interval at which the API server checks if all conditions
 	// have been met before shutting down gracefully.
+	// This option isn't exposed as a configuration item because it's used by tests only.
 	ServerShutdownCheckInterval time.Duration
 	// ServerShutdownTimeout is the maximum duration the API server waits before
 	// it abandons a graceful shutdown and exits.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -52,20 +52,24 @@ type Opts struct {
 	// Clock interfaces to a clock.
 	// Its purpose is to fake time in unit tests.
 	// Defaults to an object that proxies to the [time] package.
-	Clock                       clock.Clock
-	Config                      config.Configuration
-	DataDir                     string
-	FilterFactories             FilterFactories
-	Hosts                       []host.Host
-	IsCi                        bool
-	SkipPlugins                 bool
-	PushGateway                 *push.Pusher
-	PrometheusGatherer          prometheus.Gatherer
-	PrometheusRegisterer        prometheus.Registerer
-	RepositoryCacheTtl          time.Duration
+	Clock                clock.Clock
+	Config               config.Configuration
+	DataDir              string
+	FilterFactories      FilterFactories
+	Hosts                []host.Host
+	IsCi                 bool
+	SkipPlugins          bool
+	PushGateway          *push.Pusher
+	PrometheusGatherer   prometheus.Gatherer
+	PrometheusRegisterer prometheus.Registerer
+	RepositoryCacheTtl   time.Duration
+	// ServerShutdownCheckInterval is the interval at which the API server checks if all conditions
+	// have been met before shutting down gracefully.
 	ServerShutdownCheckInterval time.Duration
-	ServerShutdownTimeout       time.Duration
-	WorkerLoopInterval          time.Duration
+	// ServerShutdownTimeout is the maximum duration the API server waits before
+	// it abandons a graceful shutdown and exits.
+	ServerShutdownTimeout time.Duration
+	WorkerLoopInterval    time.Duration
 }
 
 func (o *Opts) SetPrometheusRegistry(reg *prometheus.Registry) {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -52,18 +52,20 @@ type Opts struct {
 	// Clock interfaces to a clock.
 	// Its purpose is to fake time in unit tests.
 	// Defaults to an object that proxies to the [time] package.
-	Clock                clock.Clock
-	Config               config.Configuration
-	DataDir              string
-	FilterFactories      FilterFactories
-	Hosts                []host.Host
-	IsCi                 bool
-	SkipPlugins          bool
-	PushGateway          *push.Pusher
-	PrometheusGatherer   prometheus.Gatherer
-	PrometheusRegisterer prometheus.Registerer
-	RepositoryCacheTtl   time.Duration
-	WorkerLoopInterval   time.Duration
+	Clock                       clock.Clock
+	Config                      config.Configuration
+	DataDir                     string
+	FilterFactories             FilterFactories
+	Hosts                       []host.Host
+	IsCi                        bool
+	SkipPlugins                 bool
+	PushGateway                 *push.Pusher
+	PrometheusGatherer          prometheus.Gatherer
+	PrometheusRegisterer        prometheus.Registerer
+	RepositoryCacheTtl          time.Duration
+	ServerShutdownCheckInterval time.Duration
+	ServerShutdownTimeout       time.Duration
+	WorkerLoopInterval          time.Duration
 }
 
 func (o *Opts) SetPrometheusRegistry(reg *prometheus.Registry) {
@@ -181,6 +183,12 @@ func Initialize(opts *Opts) error {
 	if opts.Clock == nil {
 		opts.Clock = clock.Default
 	}
+
+	shutdownTimeout, err := time.ParseDuration(opts.Config.ServerShutdownTimeout)
+	if err != nil {
+		return fmt.Errorf("setting serverShutdownTimeout '%s' is not a Go duration: %w", opts.Config.ServerShutdownTimeout, err)
+	}
+	opts.ServerShutdownTimeout = shutdownTimeout
 
 	return nil
 }

--- a/pkg/server/api/apiserver.go
+++ b/pkg/server/api/apiserver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/oapi-codegen/runtime/strictmiddleware/nethttp"
@@ -25,6 +26,11 @@ type APIServer struct {
 	Clock         clock.Clock
 	TaskService   *service.TaskService
 	WorkerService *service.WorkerService
+}
+
+// Stop gracefully stops the API server.
+func (a *APIServer) Stop(ctx context.Context, checkInterval time.Duration) error {
+	return a.WorkerService.Shutdown(ctx, checkInterval)
 }
 
 // NewAPIServerOptions are passed to [RegisterAPIServer].

--- a/pkg/server/api/task.go
+++ b/pkg/server/api/task.go
@@ -49,12 +49,12 @@ func (a *APIServer) GetTaskV1(_ context.Context, request openapi.GetTaskV1Reques
 }
 
 // ListTasksV1 implements [openapi.ServerInterface].
-func (th *APIServer) ListTasksV1(_ context.Context, request openapi.ListTasksV1RequestObject) (openapi.ListTasksV1ResponseObject, error) {
+func (a *APIServer) ListTasksV1(_ context.Context, request openapi.ListTasksV1RequestObject) (openapi.ListTasksV1ResponseObject, error) {
 	resp := openapi.ListTasksV1200JSONResponse{
 		Results: []openapi.ListTasksV1ResponseTask{},
 	}
 	listOpts := toListOptions(request.Params.ListOptions)
-	tasks, err := th.TaskService.ListTasksFromDatabase(service.ListTasksFromDatabaseOptions{
+	tasks, err := a.TaskService.ListTasksFromDatabase(service.ListTasksFromDatabaseOptions{
 		Active: request.Params.Active,
 	}, &listOpts)
 	if err != nil {

--- a/pkg/server/integration/shutdown_test.go
+++ b/pkg/server/integration/shutdown_test.go
@@ -1,0 +1,185 @@
+package integration_test
+
+import (
+	"errors"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gavv/httpexpect/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/wndhydrnt/saturn-bot/pkg/ptr"
+	"github.com/wndhydrnt/saturn-bot/pkg/server"
+	"github.com/wndhydrnt/saturn-bot/pkg/server/api/openapi"
+	"github.com/wndhydrnt/saturn-bot/pkg/task/schema"
+)
+
+func Test_Shutdown_WaitForRunningRuns(t *testing.T) {
+	task1 := schema.Task{Name: "Task1"}
+	task2 := schema.Task{Name: "Task2"}
+	taskFiles := bootstrapTaskFiles(t, []schema.Task{task1, task2})
+	opts := setupOptions(t, nil, nil)
+	opts.ServerShutdownTimeout = 10 * time.Second
+	svr := &server.Server{}
+	err := svr.Start(opts, taskFiles)
+	require.NoError(t, err, "server starts")
+
+	httpExpect := httpexpect.Default(t, opts.Config.ServerBaseUrl)
+	// Schedule a first run
+	assertApiCall(httpExpect, apiCall{
+		method: "POST",
+		path:   "/api/v1/runs",
+		requestBody: openapi.ScheduleRunV1Request{
+			TaskName: task1.Name,
+		},
+		statusCode: http.StatusOK,
+		responseBody: openapi.ScheduleRunV1Response{
+			RunID: 1,
+		},
+	})
+
+	// Schedule a second run
+	assertApiCall(httpExpect, apiCall{
+		method: "POST",
+		path:   "/api/v1/runs",
+		requestBody: openapi.ScheduleRunV1Request{
+			TaskName: task2.Name,
+		},
+		statusCode: http.StatusOK,
+		responseBody: openapi.ScheduleRunV1Response{
+			RunID: 2,
+		},
+	})
+
+	// Start work on the first run.
+	// Puts it into the "running" state.
+	assertApiCall(httpExpect, apiCall{
+		method:     "GET",
+		path:       "/api/v1/worker/work",
+		statusCode: http.StatusOK,
+		responseBody: openapi.GetWorkV1Response{
+			RunID: 1,
+			Task:  openapi.WorkTaskV1{Name: task1.Name, Hash: "8e6b6f1b27681d3bb6a30bbb92c82c9cea6cf1acdd52ca483b7e670dfff7ffab"},
+		},
+	})
+
+	// Shut down the server
+	go func() {
+		err := svr.Stop()
+		require.NoError(t, err, "server stops")
+	}()
+
+	// Try to get the second run.
+	// Should not return the next run because the server is shutting down.
+	assertApiCall(httpExpect, apiCall{
+		sleep:        5 * time.Millisecond,
+		method:       "GET",
+		path:         "/api/v1/worker/work",
+		statusCode:   http.StatusOK,
+		responseBody: openapi.GetWorkV1Response{},
+	})
+
+	// Report the result of the active run.
+	assertApiCall(httpExpect, apiCall{
+		method: "POST",
+		path:   "/api/v1/worker/work",
+		requestBody: openapi.ReportWorkV1Request{
+			RunID: 1,
+			Task: openapi.WorkTaskV1{
+				Name: task1.Name,
+			},
+			TaskResults: []openapi.ReportWorkV1TaskResult{},
+		},
+		statusCode: http.StatusCreated,
+		responseBody: openapi.ReportWorkV1Response{
+			Result: "ok",
+		},
+	})
+
+	require.Eventually(
+		t,
+		func() bool {
+			req, err := http.NewRequest(http.MethodGet, opts.Config.ServerBaseUrl+"/api/v1/worker/work", nil)
+			require.NoError(t, err)
+			req.Header.Set(openapi.HeaderApiKey, testApiKey)
+			_, err = http.DefaultClient.Do(req)
+			return errors.Is(err, syscall.ECONNREFUSED)
+		},
+		20*time.Second, // API server shutdown timeout + http server shutdown timeout
+		200*time.Millisecond,
+		"Server stops eventually and connect fails",
+	)
+}
+
+func Test_Shutdown_MarkLateRunsAsFailed(t *testing.T) {
+	task := schema.Task{Name: "Task1"}
+	taskFiles := bootstrapTaskFiles(t, []schema.Task{task})
+	opts := setupOptions(t, nil, nil)
+	opts.ServerShutdownCheckInterval = 1 * time.Nanosecond
+	svrFirst := &server.Server{}
+	err := svrFirst.Start(opts, taskFiles)
+	require.NoError(t, err, "server starts for the first time")
+
+	httpExpect := httpexpect.Default(t, opts.Config.ServerBaseUrl)
+	// Schedule a first run
+	assertApiCall(httpExpect, apiCall{
+		method: "POST",
+		path:   "/api/v1/runs",
+		requestBody: openapi.ScheduleRunV1Request{
+			TaskName: task.Name,
+		},
+		statusCode: http.StatusOK,
+		responseBody: openapi.ScheduleRunV1Response{
+			RunID: 1,
+		},
+	})
+
+	// Start work on the run.
+	// Puts it into the "running" state.
+	assertApiCall(httpExpect, apiCall{
+		method:     "GET",
+		path:       "/api/v1/worker/work",
+		statusCode: http.StatusOK,
+		responseBody: openapi.GetWorkV1Response{
+			RunID: 1,
+			Task:  openapi.WorkTaskV1{Name: task.Name, Hash: "8e6b6f1b27681d3bb6a30bbb92c82c9cea6cf1acdd52ca483b7e670dfff7ffab"},
+		},
+	})
+
+	// Shut down the server
+	err = svrFirst.Stop()
+	require.NoError(t, err, "server stops for the first time")
+
+	promReg := prometheus.NewRegistry()
+	opts.SetPrometheusRegistry(promReg)
+	// Start the server again to check the result
+	svrSecond := &server.Server{}
+	err = svrSecond.Start(opts, taskFiles)
+	require.NoError(t, err, "server starts for the second time")
+
+	// Get and compare the status of the run.
+	assertApiCall(httpExpect, apiCall{
+		sleep:      5 * time.Millisecond,
+		method:     "GET",
+		path:       "/api/v1/runs/1",
+		statusCode: http.StatusOK,
+		responseBody: openapi.GetRunV1Response{
+			Run: openapi.RunV1{
+				Error:         ptr.To("Run failed to report before shutdown"),
+				FinishedAt:    ptr.To(testDate(1, 0, 0, 4)),
+				Id:            1,
+				Reason:        openapi.Manual,
+				ScheduleAfter: testDate(1, 0, 0, 1),
+				StartedAt:     ptr.To(testDate(1, 0, 0, 3)),
+				Status:        openapi.Failed,
+				Task:          task.Name,
+			},
+		},
+	})
+
+	// Shut down the server
+	err = svrSecond.Stop()
+	require.NoError(t, err, "server stops for the second time")
+}

--- a/pkg/server/integration/shutdown_test.go
+++ b/pkg/server/integration/shutdown_test.go
@@ -29,6 +29,7 @@ func Test_Shutdown_WaitForRunningRuns(t *testing.T) {
 	httpExpect := httpexpect.Default(t, opts.Config.ServerBaseUrl)
 	// Schedule a first run
 	assertApiCall(httpExpect, apiCall{
+		sleep:  5 * time.Millisecond, // Wait for HTTP server to start up
 		method: "POST",
 		path:   "/api/v1/runs",
 		requestBody: openapi.ScheduleRunV1Request{

--- a/pkg/server/service/workerservice.go
+++ b/pkg/server/service/workerservice.go
@@ -499,7 +499,7 @@ func (ws *WorkerService) markActiveRunsAsFailed(errMsg string) error {
 
 		err = ws.ReportRun(openapi.ReportWorkV1Request{
 			Error: ptr.To(errMsg),
-			RunID: int(run.ID),
+			RunID: int(run.ID), // #nosec G115 -- no info by gosec on how to fix this
 			Task: openapi.WorkTaskV1{
 				Hash: t.Checksum(),
 				Name: t.Name,


### PR DESCRIPTION
When server and worker components shut down at the same time, the worker waits until all jobs it processes have finished.
The server doesn't wait for the worker and shuts down immediately. When the worker tries to report results, the request fails.

This change makes the server delay the shutdown if any runs are in state "running".
The server checks on a regular interval if the results of all runs have been reported.
A configurable timeout ensures that the server doesn't block forever. If the timeout has been reached, the server marks all runs that are still in state "running" as failed before it shuts down.