### PR TITLE
feat(plugin): Call method Shutdown of a plugin before stopping it

### DIFF
--- a/docs/reference/commands/plugin.md
+++ b/docs/reference/commands/plugin.md
@@ -29,6 +29,7 @@ Available Commands:
   onPrClosed  Test the onPrClosed function of a plugin
   onPrCreated Test the onPrCreated function of a plugin
   onPrMerged  Test the onPrMerged function of a plugin
+  shutdown    Test the shutdown function of a plugin
 
 Flags:
       --address string          Address of the plugin to connect to.

--- a/go.mod
+++ b/go.mod
@@ -118,3 +118,7 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	moul.io/http2curl/v2 v2.3.0 // indirect
 )
+
+replace (
+	github.com/wndhydrnt/saturn-bot-go v0.5.0 => ../saturn-bot-go
+)

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	github.com/toshi0607/chi-prometheus v0.1.4
-	github.com/wndhydrnt/saturn-bot-go v0.5.0
+	github.com/wndhydrnt/saturn-bot-go v0.6.0
 	gitlab.com/gitlab-org/api/client-go v0.116.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.4.0
@@ -117,8 +117,4 @@ require (
 	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	moul.io/http2curl/v2 v2.3.0 // indirect
-)
-
-replace (
-	github.com/wndhydrnt/saturn-bot-go v0.5.0 => ../saturn-bot-go
 )

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.34.0 h1:d3AAQJ2DRcxJYHm7OXNXtXt2as1vMDfxeIcFvhmGGm4=
 github.com/valyala/fasthttp v1.34.0/go.mod h1:epZA5N+7pY6ZaEKRmstzOuYJx9HI8DI1oaCGZpdH4h0=
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
-github.com/wndhydrnt/saturn-bot-go v0.5.0 h1:ZWgRoxbueRcuue20qdlXrTZ++3QeqvfF1jaNdQ5ZhcM=
-github.com/wndhydrnt/saturn-bot-go v0.5.0/go.mod h1:kgjTySVkesKSYKP2e8xfwOZbfeU12c8A4U7DGWPjUUo=
+github.com/wndhydrnt/saturn-bot-go v0.6.0 h1:ISai9bdIH/C6dkiCsVaflRHSL7LQPagYt3M95wLE2Fo=
+github.com/wndhydrnt/saturn-bot-go v0.6.0/go.mod h1:kgjTySVkesKSYKP2e8xfwOZbfeU12c8A4U7DGWPjUUo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -28,6 +28,7 @@ var (
 		"onPrClosed":  onPrClosedPlugin,
 		"onPrCreated": onPrCreatedPlugin,
 		"onPrMerged":  onPrMergedPlugin,
+		"shutdown":    shutdown,
 	}
 )
 
@@ -60,6 +61,11 @@ func onPrMergedPlugin(opts ExecPluginOptions, p *plugin.Plugin) (any, error) {
 	return p.OnPrMerged(&protoV1.OnPrMergedRequest{
 		Context: opts.Context,
 	})
+}
+
+func shutdown(opts ExecPluginOptions, p *plugin.Plugin) (any, error) {
+	p.Stop()
+	return nil, nil
 }
 
 // ExecPluginOptions defines all options expected by function ExecPlugin.

--- a/pkg/command/plugin.go
+++ b/pkg/command/plugin.go
@@ -63,9 +63,8 @@ func onPrMergedPlugin(opts ExecPluginOptions, p *plugin.Plugin) (any, error) {
 	})
 }
 
-func shutdown(opts ExecPluginOptions, p *plugin.Plugin) (any, error) {
-	p.Stop()
-	return nil, nil
+func shutdown(_ ExecPluginOptions, p *plugin.Plugin) (any, error) {
+	return p.Shutdown(&protoV1.ShutdownRequest{})
 }
 
 // ExecPluginOptions defines all options expected by function ExecPlugin.

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -143,6 +143,8 @@ func (p *Plugin) OnPrMerged(req *protoV1.OnPrMergedRequest) (*protoV1.OnPrMerged
 	return reply, nil
 }
 
+// Shutdown lets a plugin know that its process is about to be stopped.
+// A plugin can clean up any resources before it is stopped.
 func (p *Plugin) Shutdown(req *protoV1.ShutdownRequest) (*protoV1.ShutdownResponse, error) {
 	reply, err := p.Provider.Shutdown(req)
 	if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -16,6 +16,7 @@ import (
 	sbcontext "github.com/wndhydrnt/saturn-bot/pkg/context"
 	"github.com/wndhydrnt/saturn-bot/pkg/host"
 	"github.com/wndhydrnt/saturn-bot/pkg/log"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -168,6 +169,13 @@ func (p *Plugin) Start(opts StartOptions) error {
 
 func (p *Plugin) Stop() {
 	if p.client != nil {
+		if !p.client.Exited() {
+			_, err := p.Provider.Shutdown(&protoV1.ShutdownRequest{})
+			if err != nil {
+				log.Log().Warnw("Failed to shutdown plugin", zap.Error(err))
+			}
+		}
+
 		// It is safe to call Kill() multiple times.
 		p.client.Kill()
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -181,14 +181,14 @@ func (p *Plugin) Start(opts StartOptions) error {
 // Stop stops the plugin process.
 // It calls the Shutdown RPC method before it stops the process.
 func (p *Plugin) Stop() {
-	if p.client != nil {
-		if !p.client.Exited() {
-			_, err := p.Shutdown(&protoV1.ShutdownRequest{})
-			if err != nil {
-				log.Log().Warnw("Failed to shutdown plugin", zap.Error(err))
-			}
+	if p.Provider != nil {
+		_, err := p.Shutdown(&protoV1.ShutdownRequest{})
+		if err != nil {
+			log.Log().Warnw("Failed to shutdown plugin", zap.Error(err))
 		}
+	}
 
+	if p.client != nil {
 		// It is safe to call Kill() multiple times.
 		p.client.Kill()
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -143,6 +143,15 @@ func (p *Plugin) OnPrMerged(req *protoV1.OnPrMergedRequest) (*protoV1.OnPrMerged
 	return reply, nil
 }
 
+func (p *Plugin) Shutdown(req *protoV1.ShutdownRequest) (*protoV1.ShutdownResponse, error) {
+	reply, err := p.Provider.Shutdown(req)
+	if err != nil {
+		return nil, fmt.Errorf("rpc call Shutdown: %w", err)
+	}
+
+	return reply, nil
+}
+
 func (p *Plugin) Start(opts StartOptions) error {
 	if p.Provider == nil {
 		err := p.init(opts)
@@ -170,7 +179,7 @@ func (p *Plugin) Start(opts StartOptions) error {
 func (p *Plugin) Stop() {
 	if p.client != nil {
 		if !p.client.Exited() {
-			_, err := p.Provider.Shutdown(&protoV1.ShutdownRequest{})
+			_, err := p.Shutdown(&protoV1.ShutdownRequest{})
 			if err != nil {
 				log.Log().Warnw("Failed to shutdown plugin", zap.Error(err))
 			}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -146,7 +146,7 @@ func (p *Plugin) OnPrMerged(req *protoV1.OnPrMergedRequest) (*protoV1.OnPrMerged
 func (p *Plugin) Shutdown(req *protoV1.ShutdownRequest) (*protoV1.ShutdownResponse, error) {
 	reply, err := p.Provider.Shutdown(req)
 	if err != nil {
-		return nil, fmt.Errorf("rpc call Shutdown: %w", err)
+		return nil, fmt.Errorf("rpc Shutdown: %w", err)
 	}
 
 	return reply, nil
@@ -176,6 +176,8 @@ func (p *Plugin) Start(opts StartOptions) error {
 	return nil
 }
 
+// Stop stops the plugin process.
+// It calls the Shutdown RPC method before it stops the process.
 func (p *Plugin) Stop() {
 	if p.client != nil {
 		if !p.client.Exited() {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -192,16 +192,20 @@ func TestPlugin_Do_Error(t *testing.T) {
 	require.False(t, match)
 }
 
-func TestPlugin_Start(t *testing.T) {
+func TestPlugin_Start_Stop(t *testing.T) {
 	opts := plugin.StartOptions{Config: map[string]string{"message": "Hello World"}}
 	ctrl := gomock.NewController(t)
 	provider := pluginmock.NewMockProvider(ctrl)
 	provider.EXPECT().
 		GetPlugin(&protoV1.GetPluginRequest{Config: opts.Config}).
 		Return(&protoV1.GetPluginResponse{Name: "unittest", Priority: 10}, nil)
+	provider.EXPECT().
+		Shutdown(&protoV1.ShutdownRequest{}).
+		Return(&protoV1.ShutdownResponse{}, nil)
 
 	p := &plugin.Plugin{Provider: provider}
 	err := p.Start(opts)
+	p.Stop()
 
 	require.NoError(t, err)
 	require.Equal(t, "unittest", p.Name)

--- a/pkg/server/integration/shutdown_test.go
+++ b/pkg/server/integration/shutdown_test.go
@@ -126,6 +126,7 @@ func Test_Shutdown_MarkLateRunsAsFailed(t *testing.T) {
 	httpExpect := httpexpect.Default(t, opts.Config.ServerBaseUrl)
 	// Schedule a first run
 	assertApiCall(httpExpect, apiCall{
+		sleep:  5 * time.Millisecond, // Wait for HTTP server to start up
 		method: "POST",
 		path:   "/api/v1/runs",
 		requestBody: openapi.ScheduleRunV1Request{

--- a/test/mock/plugin/plugin.gen.go
+++ b/test/mock/plugin/plugin.gen.go
@@ -129,3 +129,18 @@ func (mr *MockProviderMockRecorder) OnPrMerged(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnPrMerged", reflect.TypeOf((*MockProvider)(nil).OnPrMerged), arg0)
 }
+
+// Shutdown mocks base method.
+func (m *MockProvider) Shutdown(arg0 *protocolv1.ShutdownRequest) (*protocolv1.ShutdownResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Shutdown", arg0)
+	ret0, _ := ret[0].(*protocolv1.ShutdownResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Shutdown indicates an expected call of Shutdown.
+func (mr *MockProviderMockRecorder) Shutdown(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockProvider)(nil).Shutdown), arg0)
+}


### PR DESCRIPTION
Implements the Shutdown RPC method introduced in protocol version [0.12.0](https://github.com/wndhydrnt/saturn-bot-protocol/releases/tag/v0.12.0).

This change is backwards-compatible with older plugins because logs a warning on error and does not fail.