### PR TITLE
fix(server): Display status "archived" if the repository of a PR has been archived

### DIFF
--- a/pkg/client/openapi.gen.go
+++ b/pkg/client/openapi.gen.go
@@ -46,12 +46,13 @@ const (
 
 // Defines values for TaskResultStateV1.
 const (
-	TaskResultStateV1Closed  TaskResultStateV1 = "closed"
-	TaskResultStateV1Error   TaskResultStateV1 = "error"
-	TaskResultStateV1Merged  TaskResultStateV1 = "merged"
-	TaskResultStateV1Open    TaskResultStateV1 = "open"
-	TaskResultStateV1Pushed  TaskResultStateV1 = "pushed"
-	TaskResultStateV1Unknown TaskResultStateV1 = "unknown"
+	TaskResultStateV1Archived TaskResultStateV1 = "archived"
+	TaskResultStateV1Closed   TaskResultStateV1 = "closed"
+	TaskResultStateV1Error    TaskResultStateV1 = "error"
+	TaskResultStateV1Merged   TaskResultStateV1 = "merged"
+	TaskResultStateV1Open     TaskResultStateV1 = "open"
+	TaskResultStateV1Pushed   TaskResultStateV1 = "pushed"
+	TaskResultStateV1Unknown  TaskResultStateV1 = "unknown"
 )
 
 // DeleteRunV1Response defines model for DeleteRunV1Response.
@@ -206,6 +207,7 @@ type ReportWorkV1TaskResult struct {
 	Result int `json:"result"`
 
 	// State State of the result.
+	// `archived` indicates that the repository of a pull request has been archived.
 	// `closed` indicates that a pull request existed and has been closed.
 	// `error` indicates that an error occurred while applying the task to the repository.
 	// `merged` indicates that a pull request has been merged.
@@ -267,6 +269,7 @@ type ScheduleRunV1Response struct {
 }
 
 // TaskResultStateV1 State of the result.
+// `archived` indicates that the repository of a pull request has been archived.
 // `closed` indicates that a pull request existed and has been closed.
 // `error` indicates that an error occurred while applying the task to the repository.
 // `merged` indicates that a pull request has been merged.
@@ -290,6 +293,7 @@ type TaskResultV1 struct {
 	RunId int `json:"runId"`
 
 	// Status State of the result.
+	// `archived` indicates that the repository of a pull request has been archived.
 	// `closed` indicates that a pull request existed and has been closed.
 	// `error` indicates that an error occurred while applying the task to the repository.
 	// `merged` indicates that a pull request has been merged.

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -29,6 +29,7 @@ const (
 	PullRequestStateOpen
 	PullRequestStateClosed
 	PullRequestStateMerged
+	PullRequestStateArchived
 )
 
 // PullRequestRaw is the raw, underlying struct of a Pull Request in a host.

--- a/pkg/host/repositorycache.go
+++ b/pkg/host/repositorycache.go
@@ -71,16 +71,6 @@ func (rc *RepositoryCache) List(hosts []Host, result chan Repository, errChan ch
 	errChan <- nil
 }
 
-func (rc *RepositoryCache) remove(repo Repository) error {
-	key := getRepositoryCacheKey(repo)
-	err := rc.Cacher.Delete(key)
-	if err != nil {
-		return fmt.Errorf("delete repository from cache: %w", err)
-	}
-
-	return nil
-}
-
 func (rc *RepositoryCache) readLastUpdateTimestamp(h Host) (*time.Time, error) {
 	meta, err := rc.readMetadata(h)
 	if err != nil {

--- a/pkg/host/repositorycache.go
+++ b/pkg/host/repositorycache.go
@@ -228,12 +228,6 @@ func (rc *RepositoryCache) updateCacheForHost(host Host) error {
 	repoIterator := host.RepositoryIterator()
 	updateCounter := 0
 	for repo := range repoIterator.ListRepositories(since) {
-		if repo.IsArchived() {
-			log.Log().Debugf("Deleting archived repository %s from cache", repo.FullName())
-			_ = rc.remove(repo)
-			continue
-		}
-
 		if err := rc.writeRepository(repo); err != nil {
 			return err
 		}

--- a/pkg/processor/result_string.go
+++ b/pkg/processor/result_string.go
@@ -23,11 +23,12 @@ func _() {
 	_ = x[ResultNoMatch-12]
 	_ = x[ResultSkip-13]
 	_ = x[ResultPushedDefaultBranch-14]
+	_ = x[ResultArchived-15]
 }
 
-const _Result_name = "ResultUnknownResultAutoMergeTooEarlyResultBranchModifiedResultChecksFailedResultConflictResultNoChangesResultPrCreatedResultPrClosedBeforeResultPrClosedResultPrMergedBeforeResultPrMergedResultPrOpenResultNoMatchResultSkipResultPushedDefaultBranch"
+const _Result_name = "ResultUnknownResultAutoMergeTooEarlyResultBranchModifiedResultChecksFailedResultConflictResultNoChangesResultPrCreatedResultPrClosedBeforeResultPrClosedResultPrMergedBeforeResultPrMergedResultPrOpenResultNoMatchResultSkipResultPushedDefaultBranchResultArchived"
 
-var _Result_index = [...]uint8{0, 13, 36, 56, 74, 88, 103, 118, 138, 152, 172, 186, 198, 211, 221, 246}
+var _Result_index = [...]uint16{0, 13, 36, 56, 74, 88, 103, 118, 138, 152, 172, 186, 198, 211, 221, 246, 260}
 
 func (i Result) String() string {
 	if i < 0 || i >= Result(len(_Result_index)-1) {

--- a/pkg/server/api/openapi/openapi.yaml
+++ b/pkg/server/api/openapi/openapi.yaml
@@ -626,6 +626,7 @@ components:
     TaskResultStateV1:
       description: |
         State of the result.
+        `archived` indicates that the repository of a pull request has been archived.
         `closed` indicates that a pull request existed and has been closed.
         `error` indicates that an error occurred while applying the task to the repository.
         `merged` indicates that a pull request has been merged.
@@ -634,6 +635,7 @@ components:
         `unknown` is a fallback value for any unexpected status.
       type: string
       enum:
+        - archived
         - closed
         - error
         - merged

--- a/pkg/server/api/openapi/server.gen.go
+++ b/pkg/server/api/openapi/server.gen.go
@@ -44,12 +44,13 @@ const (
 
 // Defines values for TaskResultStateV1.
 const (
-	TaskResultStateV1Closed  TaskResultStateV1 = "closed"
-	TaskResultStateV1Error   TaskResultStateV1 = "error"
-	TaskResultStateV1Merged  TaskResultStateV1 = "merged"
-	TaskResultStateV1Open    TaskResultStateV1 = "open"
-	TaskResultStateV1Pushed  TaskResultStateV1 = "pushed"
-	TaskResultStateV1Unknown TaskResultStateV1 = "unknown"
+	TaskResultStateV1Archived TaskResultStateV1 = "archived"
+	TaskResultStateV1Closed   TaskResultStateV1 = "closed"
+	TaskResultStateV1Error    TaskResultStateV1 = "error"
+	TaskResultStateV1Merged   TaskResultStateV1 = "merged"
+	TaskResultStateV1Open     TaskResultStateV1 = "open"
+	TaskResultStateV1Pushed   TaskResultStateV1 = "pushed"
+	TaskResultStateV1Unknown  TaskResultStateV1 = "unknown"
 )
 
 // DeleteRunV1Response defines model for DeleteRunV1Response.
@@ -204,6 +205,7 @@ type ReportWorkV1TaskResult struct {
 	Result int `json:"result"`
 
 	// State State of the result.
+	// `archived` indicates that the repository of a pull request has been archived.
 	// `closed` indicates that a pull request existed and has been closed.
 	// `error` indicates that an error occurred while applying the task to the repository.
 	// `merged` indicates that a pull request has been merged.
@@ -265,6 +267,7 @@ type ScheduleRunV1Response struct {
 }
 
 // TaskResultStateV1 State of the result.
+// `archived` indicates that the repository of a pull request has been archived.
 // `closed` indicates that a pull request existed and has been closed.
 // `error` indicates that an error occurred while applying the task to the repository.
 // `merged` indicates that a pull request has been merged.
@@ -288,6 +291,7 @@ type TaskResultV1 struct {
 	RunId int `json:"runId"`
 
 	// Status State of the result.
+	// `archived` indicates that the repository of a pull request has been archived.
 	// `closed` indicates that a pull request existed and has been closed.
 	// `error` indicates that an error occurred while applying the task to the repository.
 	// `merged` indicates that a pull request has been merged.

--- a/pkg/server/ui/runs_index.go
+++ b/pkg/server/ui/runs_index.go
@@ -24,7 +24,7 @@ type dataRunsIndexFilters struct {
 
 var (
 	runStatusOptions        = []string{string(openapi.Failed), string(openapi.Finished), string(openapi.Pending), string(openapi.Running)}
-	taskResultStatusOptions = []openapi.TaskResultStateV1{openapi.TaskResultStateV1Closed, openapi.TaskResultStateV1Error, openapi.TaskResultStateV1Merged, openapi.TaskResultStateV1Open}
+	taskResultStatusOptions = []openapi.TaskResultStateV1{openapi.TaskResultStateV1Merged, openapi.TaskResultStateV1Open, openapi.TaskResultStateV1Error, openapi.TaskResultStateV1Closed, openapi.TaskResultStateV1Archived}
 )
 
 // ListRun renders the list of known runs.

--- a/pkg/server/ui/templates.go
+++ b/pkg/server/ui/templates.go
@@ -56,7 +56,7 @@ func mapRunStatusToCssClass(status openapi.RunStatusV1) string {
 
 func mapTaskResultStatusToCssClass(status openapi.TaskResultStateV1) string {
 	switch status {
-	case openapi.TaskResultStateV1Closed:
+	case openapi.TaskResultStateV1Archived, openapi.TaskResultStateV1Closed:
 		return "is-warning"
 	case openapi.TaskResultStateV1Error:
 		return "is-danger"

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -365,6 +365,8 @@ func shouldReport(result processor.Result) bool {
 		return false
 	case processor.ResultSkip:
 		return false
+	case processor.ResultArchived:
+		return false
 	default:
 		return true
 	}
@@ -372,6 +374,8 @@ func shouldReport(result processor.Result) bool {
 
 func mapPullRequestStateToTaskResultStatus(state host.PullRequestState) client.TaskResultStateV1 {
 	switch state {
+	case host.PullRequestStateArchived:
+		return client.TaskResultStateV1Archived
 	case host.PullRequestStateClosed:
 		return client.TaskResultStateV1Closed
 	case host.PullRequestStateMerged:


### PR DESCRIPTION
When a user archives a repository while a pull request created by saturn-bot is open, then saturn-bot doesn't update the status of the pull request in its UI. The status stays as "open".

This change makes the server display the status "archived".

* The repository cache keeps archived repositories.
* The processor handles an archived repository. If a pull request is still open then it sets the result of the run to `ResultArchived`.
* The worker handles `ResultArchived` and maps it to the OpenAPI value `TaskResultStateV1Archived`.
* The server handles the OpenAPI value `TaskResultStateV1Archived` and displays it.